### PR TITLE
Added Travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,11 @@
 language: go
 
 go:
-  - 1.1
   - 1.2
   - 1.3
   - 1.4
   - 1.5
   - tip
-
-before_script:
-  - ./setup/install-go-libraries.sh
 
 script:
   - go test -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: go
+
+go:
+  - 1.1
+  - 1.2
+  - 1.3
+  - 1.4
+  - 1.5
+  - tip
+
+before_script:
+  - ./setup/install-go-libraries.sh
+
+script:
+  - go test -v

--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
-# Migrator
+# Migrator [![Build Status](https://travis-ci.org/lukaszbudnik/migrator.svg?branch=master)](https://travis-ci.org/lukaszbudnik/migrator)
 
-DB migration tool written in go
+DB migration tool written in go.
 
 # Status
 
 Work in progress.
+
+# Go versions
+
+1.2, 1.3, 1.4, 1.5, 1.6 are supported. See .travis.yml for more details.
 
 # License
 

--- a/setup/install-go-libraries.sh
+++ b/setup/install-go-libraries.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-go get github.com/stretchr/testify
-go get github.com/lib/pq
-go get -u gopkg.in/validator.v2
-go get -u gopkg.in/yaml.v2


### PR DESCRIPTION
Added Travis integration

Migrator runs on 1.2, 1.3, 1.4, 1.5, 1.6.