### PR TITLE
optimised getting migration files from disk

### DIFF
--- a/loader/disk_loader_test.go
+++ b/loader/disk_loader_test.go
@@ -10,11 +10,23 @@ import (
 func TestDiskReadDiskMigrationsNonExistingBaseDirError(t *testing.T) {
 	var config config.Config
 	config.BaseDir = "xyzabc"
+	config.SingleMigrations = []string{"migrations/config"}
 
 	loader := NewLoader(&config)
 
 	_, err := loader.GetDiskMigrations()
-	assert.Contains(t, err.Error(), "xyzabc: no such file or directory")
+	assert.Contains(t, err.Error(), "xyzabc/migrations/config: no such file or directory")
+}
+
+func TestDiskReadDiskMigrationsNonExistingMigrationsDirError(t *testing.T) {
+	var config config.Config
+	config.BaseDir = "../test"
+	config.SingleMigrations = []string{"migrations/abcdef"}
+
+	loader := NewLoader(&config)
+
+	_, err := loader.GetDiskMigrations()
+	assert.Contains(t, err.Error(), "test/migrations/abcdef: no such file or directory")
 }
 
 func TestDiskGetDiskMigrations(t *testing.T) {


### PR DESCRIPTION
Optimised getting migration files from disk. No longer uses dir walk (which previously started from the base dir). This is especially important if baseDir for example pointed to a large project repo with lots of directories and files.