### PR TITLE
fixing go-playground/validator package fetches

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ ARG SOURCE_BRANCH
 
 # build migrator
 RUN apk add git
+RUN go get -v github.com/gin-gonic/gin
 RUN go get -d -v github.com/lukaszbudnik/migrator
 RUN cd /go/src/github.com/lukaszbudnik/migrator && git checkout $SOURCE_BRANCH && ./setup.sh
 RUN cd /go/src/github.com/lukaszbudnik/migrator && \

--- a/setup.sh
+++ b/setup.sh
@@ -3,5 +3,7 @@
 # this is for dockerhub failing on fetching packages from gopkg.in
 # travis resolves this by 3 retries so adapting 3 retries here as well
 for i in {1..3}; do
+  # explicit gin get makes sure validator package is fetched before other packages are fetched
+  go get -v github.com/gin-gonic/gin
   go get -t -v ./... && break || sleep 15;
 done


### PR DESCRIPTION
there is a build error on docker hub when go-playground/validator package is not found.

In order to make sure this package is present when fetching migrator gin get was added to production Dockerfile and ./setup.sh files.