### PR TITLE
Azure Blob loader implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Further, there is an official docker image available on docker hub. [lukasz/migr
   * [Source migrations](#source-migrations)
     * [Local storage](#local-storage)
     * [AWS S3](#aws-s3)
+    * [Azure Blob](#azure-blob)
   * [Supported databases](#supported-databases)
 * [Customisation and legacy frameworks support](#customisation-and-legacy-frameworks-support)
   * [Custom tenants support](#custom-tenants-support)
@@ -577,6 +578,17 @@ baseDir: s3://lukasz-budnik-migrator-us-east-1
 ```
 
 migrator uses official AWS SDK for Go and uses a well known [default credential provider chain](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html). Please setup your env variables accordingly.
+
+### Azure Blob
+
+If `baseDir` matches `^https://.*\.blob\.core\.windows\.net/.*` regex, Azure Blob implementation is used. In such case the `baseDir` property is treated as a container URL:
+
+```
+# Azure Blob container URL
+baseDir: https://lukaszbudniktest.blob.core.windows.net/mycontainer
+```
+
+migrator uses official Azure Blob SDK for Go. Unfortunately as of the time of writing Azure Blob implementation the SDK only supported authentication using Storage Accounts and not for example much more flexible Active Directory (which is supported by the rest of Azure Go SDK). Issue to watch: [Authorization via Azure AD / RBAC](https://github.com/Azure/azure-storage-blob-go/issues/160). I plan to revisit the authorization once Azure team updates their Azure Blob SDK.
 
 ## Supported databases
 

--- a/loader/azureblob_loader.go
+++ b/loader/azureblob_loader.go
@@ -1,0 +1,127 @@
+package loader
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/Azure/azure-storage-blob-go/azblob"
+
+	"github.com/lukaszbudnik/migrator/types"
+)
+
+// azureBlobLoader is struct used for implementing Loader interface for loading migrations from Azure Blob
+type azureBlobLoader struct {
+	baseLoader
+}
+
+// GetSourceMigrations returns all migrations from Azure Blob location
+func (abl *azureBlobLoader) GetSourceMigrations() []types.Migration {
+	accountName, accountKey := os.Getenv("AZURE_STORAGE_ACCOUNT"), os.Getenv("AZURE_STORAGE_ACCESS_KEY")
+
+	if len(accountName) == 0 || len(accountKey) == 0 {
+		panic("Either the AZURE_STORAGE_ACCOUNT or AZURE_STORAGE_ACCESS_KEY environment variable is not set")
+	}
+
+	credential, err := azblob.NewSharedKeyCredential(accountName, accountKey)
+
+	p := azblob.NewPipeline(credential, azblob.PipelineOptions{})
+
+	u, err := url.Parse(abl.config.BaseDir)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	// migrator expects that container as a part of the service url
+	// for example: https://lukaszbudniktest.blob.core.windows.net/mycontainer
+	// Azure SDK will correctly parse the account and the container
+	containerURL := azblob.NewContainerURL(*u, p)
+
+	return abl.doGetSourceMigrations(containerURL)
+}
+
+func (abl *azureBlobLoader) doGetSourceMigrations(containerURL azblob.ContainerURL) []types.Migration {
+	migrations := []types.Migration{}
+
+	singleMigrationsObjects := abl.getObjectList(containerURL, abl.config.SingleMigrations)
+	tenantMigrationsObjects := abl.getObjectList(containerURL, abl.config.TenantMigrations)
+	singleScriptsObjects := abl.getObjectList(containerURL, abl.config.SingleScripts)
+	tenantScriptsObjects := abl.getObjectList(containerURL, abl.config.TenantScripts)
+
+	migrationsMap := make(map[string][]types.Migration)
+	abl.getObjects(containerURL, migrationsMap, singleMigrationsObjects, types.MigrationTypeSingleMigration)
+	abl.getObjects(containerURL, migrationsMap, tenantMigrationsObjects, types.MigrationTypeTenantMigration)
+	abl.sortMigrations(migrationsMap, &migrations)
+
+	migrationsMap = make(map[string][]types.Migration)
+	abl.getObjects(containerURL, migrationsMap, singleScriptsObjects, types.MigrationTypeSingleScript)
+	abl.sortMigrations(migrationsMap, &migrations)
+
+	migrationsMap = make(map[string][]types.Migration)
+	abl.getObjects(containerURL, migrationsMap, tenantScriptsObjects, types.MigrationTypeTenantScript)
+	abl.sortMigrations(migrationsMap, &migrations)
+
+	return migrations
+}
+
+func (abl *azureBlobLoader) getObjectList(containerURL azblob.ContainerURL, prefixes []string) []string {
+	objects := []string{}
+
+	for _, prefix := range prefixes {
+
+		for marker := (azblob.Marker{}); marker.NotDone(); { // The parens around Marker{} are required to avoid compiler error.
+
+			listBlob, err := containerURL.ListBlobsFlatSegment(abl.ctx, marker, azblob.ListBlobsSegmentOptions{Prefix: prefix + "/"})
+			if err != nil {
+				panic(err.Error())
+			}
+			marker = listBlob.NextMarker
+
+			for _, blobInfo := range listBlob.Segment.BlobItems {
+				objects = append(objects, blobInfo.Name)
+			}
+		}
+
+	}
+
+	return objects
+}
+
+func (abl *azureBlobLoader) getObjects(containerURL azblob.ContainerURL, migrationsMap map[string][]types.Migration, objects []string, migrationType types.MigrationType) {
+	for _, o := range objects {
+		blobURL := containerURL.NewBlobURL(o)
+
+		get, err := blobURL.Download(abl.ctx, 0, 0, azblob.BlobAccessConditions{}, false)
+		if err != nil {
+			panic(err.Error())
+		}
+
+		downloadedData := &bytes.Buffer{}
+		reader := get.Body(azblob.RetryReaderOptions{})
+		downloadedData.ReadFrom(reader)
+		reader.Close()
+
+		contents := downloadedData.String()
+
+		hasher := sha256.New()
+		hasher.Write([]byte(contents))
+		file := fmt.Sprintf("%s/%s", abl.config.BaseDir, o)
+		from := strings.LastIndex(file, "/")
+		sourceDir := file[0:from]
+		name := file[from+1:]
+		m := types.Migration{Name: name, SourceDir: sourceDir, File: file, MigrationType: migrationType, Contents: string(contents), CheckSum: hex.EncodeToString(hasher.Sum(nil))}
+
+		e, ok := migrationsMap[m.Name]
+		if ok {
+			e = append(e, m)
+		} else {
+			e = []types.Migration{m}
+		}
+		migrationsMap[m.Name] = e
+
+	}
+}

--- a/loader/azureblob_loader_test.go
+++ b/loader/azureblob_loader_test.go
@@ -1,0 +1,45 @@
+package loader
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/lukaszbudnik/migrator/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAzureGetSourceMigrations(t *testing.T) {
+
+	travis := os.Getenv("TRAVIS")
+	if len(travis) > 0 {
+		t.Skip("Does not work on travis due to Azure Storage Account credentials required")
+	}
+
+	config := &config.Config{
+		BaseDir:          "https://lukaszbudniktest.blob.core.windows.net/mycontainer",
+		SingleMigrations: []string{"migrations/config", "migrations/ref"},
+		TenantMigrations: []string{"migrations/tenants"},
+		SingleScripts:    []string{"migrations/config-scripts"},
+		TenantScripts:    []string{"migrations/tenants-scripts"},
+	}
+
+	loader := &azureBlobLoader{baseLoader{context.TODO(), config}}
+	migrations := loader.GetSourceMigrations()
+
+	assert.Len(t, migrations, 12)
+
+	assert.Contains(t, migrations[0].File, "migrations/config/201602160001.sql")
+	assert.Contains(t, migrations[1].File, "migrations/config/201602160002.sql")
+	assert.Contains(t, migrations[2].File, "migrations/tenants/201602160002.sql")
+	assert.Contains(t, migrations[3].File, "migrations/ref/201602160003.sql")
+	assert.Contains(t, migrations[4].File, "migrations/tenants/201602160003.sql")
+	assert.Contains(t, migrations[5].File, "migrations/ref/201602160004.sql")
+	assert.Contains(t, migrations[6].File, "migrations/tenants/201602160004.sql")
+	assert.Contains(t, migrations[7].File, "migrations/tenants/201602160005.sql")
+	assert.Contains(t, migrations[8].File, "migrations/config-scripts/200012181227.sql")
+	assert.Contains(t, migrations[9].File, "migrations/tenants-scripts/200001181228.sql")
+	assert.Contains(t, migrations[10].File, "migrations/tenants-scripts/a.sql")
+	assert.Contains(t, migrations[11].File, "migrations/tenants-scripts/b.sql")
+
+}

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -2,6 +2,7 @@ package loader
 
 import (
 	"context"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -21,6 +22,9 @@ type Factory func(context.Context, *config.Config) Loader
 func New(ctx context.Context, config *config.Config) Loader {
 	if strings.HasPrefix(config.BaseDir, "s3://") {
 		return &s3Loader{baseLoader{ctx, config}}
+	}
+	if matched, _ := regexp.Match(`^https://.*\.blob\.core\.windows\.net/.*`, []byte(config.BaseDir)); matched {
+		return &azureBlobLoader{baseLoader{ctx, config}}
 	}
 	return &diskLoader{baseLoader{ctx, config}}
 }

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -1,0 +1,33 @@
+package loader
+
+import (
+	"context"
+	"testing"
+
+	"github.com/lukaszbudnik/migrator/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewDiskLoader(t *testing.T) {
+	config := &config.Config{
+		BaseDir: "/path/to/baseDir",
+	}
+	loader := New(context.TODO(), config)
+	assert.IsType(t, &diskLoader{}, loader)
+}
+
+func TestNewAzureBlobLoader(t *testing.T) {
+	config := &config.Config{
+		BaseDir: "https://lukaszbudniktest.blob.core.windows.net/mycontainer",
+	}
+	loader := New(context.TODO(), config)
+	assert.IsType(t, &azureBlobLoader{}, loader)
+}
+
+func TestNewS3Loader(t *testing.T) {
+	config := &config.Config{
+		BaseDir: "s3://lukaszbudniktest-bucket",
+	}
+	loader := New(context.TODO(), config)
+	assert.IsType(t, &s3Loader{}, loader)
+}


### PR DESCRIPTION
Azure Blob loader implementation is automatically picked up by migrator when baseDir matches the following regex pattern:

The `baseDir` must point to a container URL:

```yaml
# Azure Blob container URL
baseDir: https://lukaszbudniktest.blob.core.windows.net/mycontainer
```