### PR TITLE
renamed baseDir to baseLocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Sample HTTP response:
 < Date: Wed, 01 Jan 2020 17:31:57 GMT
 < Content-Length: 277
 
-baseDir: test/migrations
+baseLocation: test/migrations
 driver: postgres
 dataSource: user=postgres dbname=migrator_test host=127.0.0.1 port=32776 sslmode=disable
   connect_timeout=1
@@ -448,7 +448,7 @@ When running migrator from docker we need to update `migrator.yaml` (generated i
 
 ```
 sed -i "s/host=[^ ]* port=[^ ]*/host=migrator-postgres port=5432/g" test/migrator.yaml
-sed -i "s/baseDir: .*/baseDir: \/data\/migrations/g" test/migrator.yaml
+sed -i "s/baseLocation: .*/baseLocation: \/data\/migrations/g" test/migrator.yaml
 docker run --name migrator-test -p 8080:8080 -v $PWD/test:/data -e MIGRATOR_YAML=/data/migrator.yaml -d --link migrator-postgres lukasz/migrator
 ```
 
@@ -500,7 +500,7 @@ migrator configuration file is a simple YAML file. Take a look at a sample `migr
 
 ```yaml
 # required, base directory where all migrations are stored, see singleSchemas and tenantSchemas below
-baseDir: test/migrations
+baseLocation: test/migrations
 # required, SQL go driver implementation used, see section "Supported databases"
 driver: postgres
 # required, dataSource format is specific to SQL go driver implementation used, see section "Supported databases"
@@ -511,18 +511,18 @@ tenantSelectSQL: "select name from migrator.migrator_tenants"
 tenantInsertSQL: "insert into migrator.migrator_tenants (name) values ($1)"
 # optional, override only if you have a specific schema placeholder, default is:
 schemaPlaceHolder: {schema}
-# required, directories of single schema SQL migrations, these are subdirectories of baseDir
+# required, directories of single schema SQL migrations, these are subdirectories of baseLocation
 singleMigrations:
   - public
   - ref
   - config
-# optional, directories of tenant schemas SQL migrations, these are subdirectories of baseDir
+# optional, directories of tenant schemas SQL migrations, these are subdirectories of baseLocation
 tenantMigrations:
   - tenants
-# optional, directories of single SQL scripts which are applied always, these are subdirectories of baseDir
+# optional, directories of single SQL scripts which are applied always, these are subdirectories of baseLocation
 singleScripts:
   - config-scripts
-# optional, directories of tenant SQL script which are applied always for all tenants, these are subdirectories of baseDir
+# optional, directories of tenant SQL script which are applied always for all tenants, these are subdirectories of baseLocation
 tenantScripts:
   - tenants-scripts
 # optional, default is:
@@ -559,33 +559,33 @@ Migrations can be read either from local disk or from S3 (I'm open to contributi
 
 ### Local storage
 
-If `baseDir` property is a path (either relative or absolute) local storage implementation is used:
+If `baseLocation` property is a path (either relative or absolute) local storage implementation is used:
 
 ```
 # relative path
-baseDir: test/migrations
+baseLocation: test/migrations
 # absolute path
-baseDir: /project/migrations
+baseLocation: /project/migrations
 ```
 
 ### AWS S3
 
-If `baseDir` starts with `s3://` prefix, AWS S3 implementation is used. In such case the `baseDir` property is treated as a bucket name:
+If `baseLocation` starts with `s3://` prefix, AWS S3 implementation is used. In such case the `baseLocation` property is treated as a bucket name:
 
 ```
 # S3 bucket
-baseDir: s3://lukasz-budnik-migrator-us-east-1
+baseLocation: s3://lukasz-budnik-migrator-us-east-1
 ```
 
 migrator uses official AWS SDK for Go and uses a well known [default credential provider chain](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html). Please setup your env variables accordingly.
 
 ### Azure Blob
 
-If `baseDir` matches `^https://.*\.blob\.core\.windows\.net/.*` regex, Azure Blob implementation is used. In such case the `baseDir` property is treated as a container URL:
+If `baseLocation` matches `^https://.*\.blob\.core\.windows\.net/.*` regex, Azure Blob implementation is used. In such case the `baseLocation` property is treated as a container URL:
 
 ```
 # Azure Blob container URL
-baseDir: https://lukaszbudniktest.blob.core.windows.net/mycontainer
+baseLocation: https://lukaszbudniktest.blob.core.windows.net/mycontainer
 ```
 
 migrator uses official Azure Blob SDK for Go. Unfortunately as of the time of writing Azure Blob implementation the SDK only supported authentication using Storage Accounts and not for example much more flexible Active Directory (which is supported by the rest of Azure Go SDK). Issue to watch: [Authorization via Azure AD / RBAC](https://github.com/Azure/azure-storage-blob-go/issues/160). I plan to revisit the authorization once Azure team updates their Azure Blob SDK.

--- a/config/config.go
+++ b/config/config.go
@@ -12,7 +12,7 @@ import (
 
 // Config represents Migrator's yaml configuration file
 type Config struct {
-	BaseDir           string   `yaml:"baseDir" validate:"required"`
+	BaseLocation      string   `yaml:"baseLocation" validate:"required"`
 	Driver            string   `yaml:"driver" validate:"required"`
 	DataSource        string   `yaml:"dataSource" validate:"required"`
 	TenantSelectSQL   string   `yaml:"tenantSelectSQL,omitempty"`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -13,7 +13,7 @@ import (
 func TestFromFile(t *testing.T) {
 	config, err := FromFile("../test/migrator-test.yaml")
 	assert.Nil(t, err)
-	assert.Equal(t, "test/migrations", config.BaseDir)
+	assert.Equal(t, "test/migrations", config.BaseLocation)
 	assert.Equal(t, "select name from migrator.migrator_tenants", config.TenantSelectSQL)
 	assert.Equal(t, "postgres", config.Driver)
 	assert.Equal(t, "user=postgres dbname=migrator_test host=192.168.99.100 port=55432 sslmode=disable", config.DataSource)
@@ -28,7 +28,7 @@ func TestFromFile(t *testing.T) {
 func TestWithEnvFromFile(t *testing.T) {
 	config, err := FromFile("../test/migrator-test-envs.yaml")
 	assert.Nil(t, err)
-	assert.Equal(t, os.Getenv("TERM"), config.BaseDir)
+	assert.Equal(t, os.Getenv("TERM"), config.BaseLocation)
 	assert.Equal(t, os.Getenv("PATH"), config.TenantSelectSQL)
 	assert.Equal(t, os.Getenv("GOPATH"), config.TenantInsertSQL)
 	assert.Equal(t, os.Getenv("PWD"), config.Driver)
@@ -44,7 +44,7 @@ func TestWithEnvFromFile(t *testing.T) {
 func TestConfigString(t *testing.T) {
 	config := &Config{"/opt/app/migrations", "postgres", "user=p dbname=db host=localhost", "select abc", "insert into table", ":tenant", []string{"ref"}, []string{"tenants"}, []string{"procedures"}, []string{}, "8181", "", "https://hooks.slack.com/services/TTT/BBB/XXX", []string{}}
 	// check if go naming convention applies
-	expected := `baseDir: /opt/app/migrations
+	expected := `baseLocation: /opt/app/migrations
 driver: postgres
 dataSource: user=p dbname=db host=localhost
 tenantSelectSQL: select abc

--- a/contrib/aws-ecs-ecr-secretsmanager-rds-s3/migrator.yaml
+++ b/contrib/aws-ecs-ecr-secretsmanager-rds-s3/migrator.yaml
@@ -1,4 +1,4 @@
-baseDir: s3://your-bucket-migrator
+baseLocation: s3://your-bucket-migrator
 driver: postgres
 dataSource: "user=${DATABASE_USERNAME} password=${DATABASE_PASSWORD} dbname=${DATABASE_NAME} host=${DATABASE_HOST}"
 singleMigrations:

--- a/contrib/kubernetes-aws-eks/README.md
+++ b/contrib/kubernetes-aws-eks/README.md
@@ -15,7 +15,7 @@ Further, the support of this new feature was limited as of the time of writing t
 
 ## S3 - upload test migrations
 
-Create S3 bucket in same region you will be deploying AWS EKS. Update `baseDir` property in `migrator.yaml`.
+Create S3 bucket in same region you will be deploying AWS EKS. Update `baseDir` (v4.0 and earlier versions) or `baseLocation` (v5.0+) property in `migrator.yaml`.
 
 You can also use test migrations to play around with migrator:
 

--- a/contrib/kubernetes-aws-eks/migrator.yaml
+++ b/contrib/kubernetes-aws-eks/migrator.yaml
@@ -1,4 +1,4 @@
-baseDir: s3://your-bucket-migrator
+baseLocation: s3://your-bucket-migrator
 driver: postgres
 dataSource: "user=${DATABASE_USERNAME} password=${DATABASE_PASSWORD} dbname=${DATABASE_NAME} host=${DATABASE_HOST}"
 singleMigrations:

--- a/loader/azureblob_loader.go
+++ b/loader/azureblob_loader.go
@@ -31,7 +31,7 @@ func (abl *azureBlobLoader) GetSourceMigrations() []types.Migration {
 
 	p := azblob.NewPipeline(credential, azblob.PipelineOptions{})
 
-	u, err := url.Parse(abl.config.BaseDir)
+	u, err := url.Parse(abl.config.BaseLocation)
 	if err != nil {
 		panic(err.Error())
 	}
@@ -109,7 +109,7 @@ func (abl *azureBlobLoader) getObjects(containerURL azblob.ContainerURL, migrati
 
 		hasher := sha256.New()
 		hasher.Write([]byte(contents))
-		file := fmt.Sprintf("%s/%s", abl.config.BaseDir, o)
+		file := fmt.Sprintf("%s/%s", abl.config.BaseLocation, o)
 		from := strings.LastIndex(file, "/")
 		sourceDir := file[0:from]
 		name := file[from+1:]

--- a/loader/azureblob_loader_test.go
+++ b/loader/azureblob_loader_test.go
@@ -17,7 +17,7 @@ func TestAzureGetSourceMigrations(t *testing.T) {
 	}
 
 	config := &config.Config{
-		BaseDir:          "https://lukaszbudniktest.blob.core.windows.net/mycontainer",
+		BaseLocation:     "https://lukaszbudniktest.blob.core.windows.net/mycontainer",
 		SingleMigrations: []string{"migrations/config", "migrations/ref"},
 		TenantMigrations: []string{"migrations/tenants"},
 		SingleScripts:    []string{"migrations/config-scripts"},

--- a/loader/disk_loader.go
+++ b/loader/disk_loader.go
@@ -21,9 +21,9 @@ type diskLoader struct {
 func (dl *diskLoader) GetSourceMigrations() []types.Migration {
 	migrations := []types.Migration{}
 
-	absBaseDir, err := filepath.Abs(dl.config.BaseDir)
+	absBaseDir, err := filepath.Abs(dl.config.BaseLocation)
 	if err != nil {
-		panic(fmt.Sprintf("Could not convert baseDir to absolute path: %v", err.Error()))
+		panic(fmt.Sprintf("Could not convert baseLocation to absolute path: %v", err.Error()))
 	}
 
 	singleMigrationsDirs := dl.getDirs(absBaseDir, dl.config.SingleMigrations)
@@ -70,7 +70,7 @@ func (dl *diskLoader) readFromDirs(migrations map[string][]types.Migration, sour
 				}
 				hasher := sha256.New()
 				hasher.Write([]byte(contents))
-				name := strings.Replace(file.Name(), dl.config.BaseDir, "", 1)
+				name := strings.Replace(file.Name(), dl.config.BaseLocation, "", 1)
 				m := types.Migration{Name: name, SourceDir: sourceDir, File: filepath.Join(sourceDir, file.Name()), MigrationType: migrationType, Contents: string(contents), CheckSum: hex.EncodeToString(hasher.Sum(nil))}
 
 				e, ok := migrations[m.Name]

--- a/loader/disk_loader_test.go
+++ b/loader/disk_loader_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestDiskReadDiskMigrationsNonExistingBaseDirError(t *testing.T) {
+func TestDiskReadDiskMigrationsNonExistingBaseLocationError(t *testing.T) {
 	var config config.Config
-	config.BaseDir = "xyzabc"
+	config.BaseLocation = "xyzabc"
 	config.SingleMigrations = []string{"migrations/config"}
 
 	loader := New(context.TODO(), &config)
@@ -34,7 +34,7 @@ func TestDiskReadDiskMigrationsNonExistingBaseDirError(t *testing.T) {
 
 func TestDiskReadDiskMigrationsNonExistingMigrationsDirError(t *testing.T) {
 	var config config.Config
-	config.BaseDir = "../test"
+	config.BaseLocation = "../test"
 	config.SingleMigrations = []string{"migrations/abcdef"}
 
 	loader := New(context.TODO(), &config)
@@ -58,7 +58,7 @@ func TestDiskReadDiskMigrationsNonExistingMigrationsDirError(t *testing.T) {
 
 func TestDiskGetDiskMigrations(t *testing.T) {
 	var config config.Config
-	config.BaseDir = "../test"
+	config.BaseLocation = "../test"
 	config.SingleMigrations = []string{"migrations/config", "migrations/ref"}
 	config.TenantMigrations = []string{"migrations/tenants"}
 	config.SingleScripts = []string{"migrations/config-scripts"}

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -20,10 +20,10 @@ type Factory func(context.Context, *config.Config) Loader
 
 // New returns new instance of Loader, currently DiskLoader is available
 func New(ctx context.Context, config *config.Config) Loader {
-	if strings.HasPrefix(config.BaseDir, "s3://") {
+	if strings.HasPrefix(config.BaseLocation, "s3://") {
 		return &s3Loader{baseLoader{ctx, config}}
 	}
-	if matched, _ := regexp.Match(`^https://.*\.blob\.core\.windows\.net/.*`, []byte(config.BaseDir)); matched {
+	if matched, _ := regexp.Match(`^https://.*\.blob\.core\.windows\.net/.*`, []byte(config.BaseLocation)); matched {
 		return &azureBlobLoader{baseLoader{ctx, config}}
 	}
 	return &diskLoader{baseLoader{ctx, config}}

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestNewDiskLoader(t *testing.T) {
 	config := &config.Config{
-		BaseDir: "/path/to/baseDir",
+		BaseLocation: "/path/to/baseDir",
 	}
 	loader := New(context.TODO(), config)
 	assert.IsType(t, &diskLoader{}, loader)
@@ -18,7 +18,7 @@ func TestNewDiskLoader(t *testing.T) {
 
 func TestNewAzureBlobLoader(t *testing.T) {
 	config := &config.Config{
-		BaseDir: "https://lukaszbudniktest.blob.core.windows.net/mycontainer",
+		BaseLocation: "https://lukaszbudniktest.blob.core.windows.net/mycontainer",
 	}
 	loader := New(context.TODO(), config)
 	assert.IsType(t, &azureBlobLoader{}, loader)
@@ -26,7 +26,7 @@ func TestNewAzureBlobLoader(t *testing.T) {
 
 func TestNewS3Loader(t *testing.T) {
 	config := &config.Config{
-		BaseDir: "s3://lukaszbudniktest-bucket",
+		BaseLocation: "s3://lukaszbudniktest-bucket",
 	}
 	loader := New(context.TODO(), config)
 	assert.IsType(t, &s3Loader{}, loader)

--- a/loader/s3_loader.go
+++ b/loader/s3_loader.go
@@ -56,7 +56,7 @@ func (s3l *s3Loader) doGetSourceMigrations(client s3iface.S3API) []types.Migrati
 func (s3l *s3Loader) getObjectList(client s3iface.S3API, prefixes []string) []*string {
 	objects := []*string{}
 
-	bucket := strings.Replace(s3l.config.BaseDir, "s3://", "", 1)
+	bucket := strings.Replace(s3l.config.BaseLocation, "s3://", "", 1)
 
 	for _, prefix := range prefixes {
 
@@ -86,7 +86,7 @@ func (s3l *s3Loader) getObjectList(client s3iface.S3API, prefixes []string) []*s
 }
 
 func (s3l *s3Loader) getObjects(client s3iface.S3API, migrationsMap map[string][]types.Migration, objects []*string, migrationType types.MigrationType) {
-	bucket := strings.Replace(s3l.config.BaseDir, "s3://", "", 1)
+	bucket := strings.Replace(s3l.config.BaseLocation, "s3://", "", 1)
 
 	objectInput := &s3.GetObjectInput{Bucket: aws.String(bucket)}
 	for _, o := range objects {
@@ -101,7 +101,7 @@ func (s3l *s3Loader) getObjects(client s3iface.S3API, migrationsMap map[string][
 
 		hasher := sha256.New()
 		hasher.Write([]byte(contents))
-		file := fmt.Sprintf("%s/%s", s3l.config.BaseDir, *o)
+		file := fmt.Sprintf("%s/%s", s3l.config.BaseLocation, *o)
 		from := strings.LastIndex(file, "/")
 		sourceDir := file[0:from]
 		name := file[from+1:]

--- a/loader/s3_loader_test.go
+++ b/loader/s3_loader_test.go
@@ -62,7 +62,7 @@ func TestS3GetSourceMigrations(t *testing.T) {
 	mock := &mockS3Client{}
 
 	config := &config.Config{
-		BaseDir:          "s3://lukasz-budnik-migrator-us-east-1",
+		BaseLocation:     "s3://lukasz-budnik-migrator-us-east-1",
 		SingleMigrations: []string{"migrations/config", "migrations/ref"},
 		TenantMigrations: []string{"migrations/tenants"},
 		SingleScripts:    []string{"migrations/config-scripts"},

--- a/test/migrator-mssql.yaml
+++ b/test/migrator-mssql.yaml
@@ -1,4 +1,4 @@
-baseDir: test/migrations
+baseLocation: test/migrations
 driver: sqlserver
 dataSource: "A"
 singleMigrations:

--- a/test/migrator-mysql.yaml
+++ b/test/migrator-mysql.yaml
@@ -1,4 +1,4 @@
-baseDir: test/migrations
+baseLocation: test/migrations
 driver: mysql
 dataSource: "A"
 singleMigrations:

--- a/test/migrator-mysql.yaml.travis
+++ b/test/migrator-mysql.yaml.travis
@@ -1,4 +1,4 @@
-baseDir: test/migrations
+baseLocation: test/migrations
 driver: mysql
 dataSource: "root:@tcp(127.0.0.1:3306)/migrator_test?parseTime=true&timeout=1s"
 singleMigrations:

--- a/test/migrator-overrides.yaml
+++ b/test/migrator-overrides.yaml
@@ -1,4 +1,4 @@
-baseDir: test/migrations
+baseLocation: test/migrations
 driver: postgres
 dataSource: "user=postgres dbname=A host=B port=C sslmode=disable"
 tenantSelectSQL: select somename from someschema.sometable

--- a/test/migrator-postgresql.yaml
+++ b/test/migrator-postgresql.yaml
@@ -1,4 +1,4 @@
-baseDir: test/migrations
+baseLocation: test/migrations
 driver: postgres
 dataSource: "user=postgres dbname=A host=B port=C sslmode=disable connect_timeout=1"
 singleMigrations:

--- a/test/migrator-postgresql.yaml.travis
+++ b/test/migrator-postgresql.yaml.travis
@@ -1,5 +1,5 @@
 # migrator configuration
-baseDir: test/migrations
+baseLocation: test/migrations
 driver: postgres
 dataSource: "user=postgres dbname=migrator_test host=127.0.0.1 port=5432 sslmode=disable connect_timeout=1"
 singleMigrations:

--- a/test/migrator-test-envs.yaml
+++ b/test/migrator-test-envs.yaml
@@ -1,5 +1,5 @@
 # migrator configuration
-baseDir: ${TERM}
+baseLocation: ${TERM}
 driver: ${PWD}
 dataSource: "lets_assume_password=${HOME}&and_something_else=${USER}&param=value"
 # override only if you have own specific way of determining tenants

--- a/test/migrator-test.yaml
+++ b/test/migrator-test.yaml
@@ -1,5 +1,5 @@
 # migrator configuration
-baseDir: test/migrations
+baseLocation: test/migrations
 driver: postgres
 dataSource: "user=postgres dbname=migrator_test host=192.168.99.100 port=55432 sslmode=disable"
 # override only if you have own specific way of determining tenants

--- a/test/performance/test.sh
+++ b/test/performance/test.sh
@@ -11,7 +11,7 @@ cp test/migrator.yaml test/performance
 
 cd test/performance
 cat migrator.yaml
-sed -i "s/baseDir: [^ ]*/baseDir: migrations/g" migrator.yaml
+sed -i "s/baseLocation: [^ ]*/baseLocation: migrations/g" migrator.yaml
 echo 'schemaPlaceHolder: ":tenant"' >> migrator.yaml
 
 # generate test migrtations


### PR DESCRIPTION
**Breaking Change**

renamed `baseDir` to `baseLocation` in YAML config to better reflect non-disk loaders like AWS S3 and Azure Blob.

This is a breaking change and will be introduced in v5.0. However v5.0 will only contain Azure Blob loader implementation so all other customers can still run on v4.0.