### PR TITLE
implemented backward compatibility for baseDir and baseLocation

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -7,11 +7,13 @@ import (
 	"strings"
 
 	"github.com/go-playground/validator"
+	"github.com/lukaszbudnik/migrator/common"
 	"gopkg.in/yaml.v2"
 )
 
 // Config represents Migrator's yaml configuration file
 type Config struct {
+	BaseDir           string   `yaml:"baseDir,omitempty"`
 	BaseLocation      string   `yaml:"baseLocation" validate:"required"`
 	Driver            string   `yaml:"driver" validate:"required"`
 	DataSource        string   `yaml:"dataSource" validate:"required"`
@@ -50,6 +52,11 @@ func FromBytes(contents []byte) (*Config, error) {
 
 	if err := yaml.Unmarshal(contents, &config); err != nil {
 		return nil, err
+	}
+
+	if len(config.BaseDir) > 0 && len(config.BaseLocation) == 0 {
+		common.Log("WARN", "Deprecated: config property `baseDir` will be removed in migrator v6.0, please rename it to `baseLocation`")
+		config.BaseLocation = config.BaseDir
 	}
 
 	validate := validator.New()

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -10,6 +10,21 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+func TestFromFileBackwardCompatibile(t *testing.T) {
+	config, err := FromFile("../test/migrator-test-backward-compatibile.yaml")
+	assert.Nil(t, err)
+	assert.Equal(t, "test/migrations", config.BaseLocation)
+	assert.Equal(t, "select name from migrator.migrator_tenants", config.TenantSelectSQL)
+	assert.Equal(t, "postgres", config.Driver)
+	assert.Equal(t, "user=postgres dbname=migrator_test host=192.168.99.100 port=55432 sslmode=disable", config.DataSource)
+	assert.Equal(t, []string{"tenants"}, config.TenantMigrations)
+	assert.Equal(t, []string{"public", "ref", "config"}, config.SingleMigrations)
+	assert.Equal(t, "8811", config.Port)
+	assert.Equal(t, "{schema}", config.SchemaPlaceHolder)
+	assert.Equal(t, "https://slack.com/api/api.test", config.WebHookURL)
+	assert.Equal(t, []string{"Authorization: Basic QWxhZGRpbjpPcGVuU2VzYW1l", "Content-Type: application/json", "X-CustomHeader: value1,value2"}, config.WebHookHeaders)
+}
+
 func TestFromFile(t *testing.T) {
 	config, err := FromFile("../test/migrator-test.yaml")
 	assert.Nil(t, err)
@@ -42,7 +57,7 @@ func TestWithEnvFromFile(t *testing.T) {
 }
 
 func TestConfigString(t *testing.T) {
-	config := &Config{"/opt/app/migrations", "postgres", "user=p dbname=db host=localhost", "select abc", "insert into table", ":tenant", []string{"ref"}, []string{"tenants"}, []string{"procedures"}, []string{}, "8181", "", "https://hooks.slack.com/services/TTT/BBB/XXX", []string{}}
+	config := &Config{"", "/opt/app/migrations", "postgres", "user=p dbname=db host=localhost", "select abc", "insert into table", ":tenant", []string{"ref"}, []string{"tenants"}, []string{"procedures"}, []string{}, "8181", "", "https://hooks.slack.com/services/TTT/BBB/XXX", []string{}}
 	// check if go naming convention applies
 	expected := `baseLocation: /opt/app/migrations
 driver: postgres

--- a/test/migrator-test-backward-compatibile.yaml
+++ b/test/migrator-test-backward-compatibile.yaml
@@ -1,0 +1,19 @@
+# migrator configuration
+baseDir: test/migrations
+driver: postgres
+dataSource: "user=postgres dbname=migrator_test host=192.168.99.100 port=55432 sslmode=disable"
+# override only if you have own specific way of determining tenants
+tenantSelectSQL: "select name from migrator.migrator_tenants"
+schemaPlaceHolder: "{schema}"
+port: 8811
+singleMigrations:
+  - public
+  - ref
+  - config
+tenantMigrations:
+  - tenants
+webHookURL: https://slack.com/api/api.test
+webHookHeaders:
+  - "Authorization: Basic QWxhZGRpbjpPcGVuU2VzYW1l"
+  - "Content-Type: application/json"
+  - "X-CustomHeader: value1,value2"


### PR DESCRIPTION
implemented backward compatibility for `baseDir` (deprecated) and `baseLocation` (introduced in v5.0), migrator will print a WARN message when old config property is used, baseDir to be removed in v6.0.

For example:

```
2020/02/06 11:14:27.717928 [/Users/lukasz/go/src/github.com/lukaszbudnik/migrator/config/config.go:46] WARN Deprecated: config property `baseDir` will be removed in migrator v6.0, please rename it to `baseLocation`
```