### PR TITLE
Introduced GraphQL endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,16 @@ Further, there is an official docker image available on docker hub. [lukasz/migr
 
 * [Usage](#usage)
   * [GET /](#get-)
-  * [GET /v1/config](#get-v1config)
-  * [GET /v1/migrations/source](#get-v1migrationssource)
-  * [GET /v1/migrations/applied](#get-v1migrationsapplied)
-  * [POST /v1/migrations](#post-v1migrations)
-  * [GET /v1/tenants](#get-v1tenants)
-  * [POST /v1/tenants](#post-v1tenants)
+  * [/v2 - GraphQL-based API](#v2)
+    * [GET /v2/config](#get-v2config)
+    * [POST /v2/service](#post-v2service)
+  * [/v1](#v1) **deprecated in v2020.1.0, sunset in next major release**
+    * [GET /v1/config](#get-v1config)
+    * [GET /v1/migrations/source](#get-v1migrationssource)
+    * [GET /v1/migrations/applied](#get-v1migrationsapplied)
+    * [POST /v1/migrations](#post-v1migrations)
+    * [GET /v1/tenants](#get-v1tenants)
+    * [POST /v1/tenants](#post-v1tenants)
   * [Request tracing](#request-tracing)
 * [Quick Start Guide](#quick-start-guide)
   * [1. Get the migrator project](#1-get-the-migrator-project)
@@ -64,22 +68,48 @@ curl -v http://localhost:8080/
 Sample HTTP response:
 
 ```
-< HTTP/1.1 200 OK
-< Content-Type: application/json; charset=utf-8
-< Date: Wed, 08 Jan 2020 09:13:58 GMT
-< Content-Length: 142
 
-{
-  "release": "dev-v4.0.1",
-  "commitSha": "300ee8b98f4d6a4725d38b3676accd5a361d7a04",
-  "commitDate": "2020-01-07T14:52:00+01:00",
-  "apiVersions": [
-    "v1"
-  ]
-}
 ```
 
+## /v2 - GraphQL-based API
+
+API v2 was introduced in migrator v2020.1.0 (old versioning v5.0). This is none backward compatible API. The major difference is that v2 is GraphQL-based API.
+
+## GET /v2/config
+
+Returns migrator's config as `application/x-yaml`.
+
+Sample request:
+
+```
+curl -v http://localhost:8080/v1/config
+```
+
+Sample HTTP response:
+
+```
+```
+
+## POST /v2/service
+
+This is a GraphQL endpoint which handles both query and mutation.
+
+The GraphQL schema is as follows:
+
+```
+```
+
+An example of HTTP request fetching source migrations with filters, all applied migrations for specific schema, and all tenants in a single query is show below:
+
+```
+
+```
+
+## /v1 **deprecated in v2020.1.0, sunset in next major release**
+
 API v1 was introduced in migrator v4.0. Any non API-breaking changes will be added to v1. Any significant change or an API-breaking change will be added to API v2.
+
+As of migrator v2020.1.0 this API is deprecated and will be sunset in the next major release.
 
 ## GET /v1/config
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Sample HTTP response:
 
 ## /v2 - GraphQL-based API
 
-API v2 was introduced in migrator v2020.1.0 (old versioning v5.0) and is a GraphQL-based API.
+API v2 was introduced in migrator v2020.1.0 (old versioning convention v5.0) and is a GraphQL-based API.
 
 ## GET /v2/config
 
@@ -82,7 +82,22 @@ Returns migrator's config as `application/x-yaml`.
 Sample request:
 
 ```
-curl -v http://localhost:8080/v1/config
+curl -v http://localhost:8080/v2/config
+```
+
+Sample HTTP response:
+
+```
+```
+
+## GET /v2/schema
+
+Returns migrator's config as `plain/text`.
+
+Sample request:
+
+```
+curl -v http://localhost:8080/v2/schema
 ```
 
 Sample HTTP response:
@@ -99,11 +114,18 @@ The GraphQL schema is as follows:
 ```
 ```
 
+For a quick start guide below are a couple of curl examples.
+
+```
+```
+
+Further there are code generators available which can generate client code based on GraphQL schema. This would be the preferred way of consuming migrator's GraphQL endpoint.
+
 ## /v1 - deprecated available in v4.x and v2020.x
 
 API v1 is available in migrator v4.x and v2020.x.
 
-Important: As of migrator v2020.1.0 this API is deprecated and will sunset in the next major release - v2021.1.0).
+**Important**: As of migrator v2020.1.0 this API is deprecated and will sunset in the next major release - v2021.1.0.
 
 ## GET /v1/config
 

--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ Further, there is an official docker image available on docker hub. [lukasz/migr
 
 * [Usage](#usage)
   * [GET /](#get-)
-  * [/v2 - GraphQL-based API](#v2)
+  * [/v2 - GraphQL-based API](#v2---graphql-based-api)
     * [GET /v2/config](#get-v2config)
     * [POST /v2/service](#post-v2service)
-  * [/v1](#v1) **deprecated in v2020.1.0, sunset in next major release**
+  * [/v1 - deprecated available in v4.x and v2020.x](#v1---deprecated-available-in-v4x-and-v2020x)
     * [GET /v1/config](#get-v1config)
     * [GET /v1/migrations/source](#get-v1migrationssource)
     * [GET /v1/migrations/applied](#get-v1migrationsapplied)
@@ -73,7 +73,7 @@ Sample HTTP response:
 
 ## /v2 - GraphQL-based API
 
-API v2 was introduced in migrator v2020.1.0 (old versioning v5.0). This is none backward compatible API. The major difference is that v2 is GraphQL-based API.
+API v2 was introduced in migrator v2020.1.0 (old versioning v5.0) and is a GraphQL-based API.
 
 ## GET /v2/config
 
@@ -92,24 +92,18 @@ Sample HTTP response:
 
 ## POST /v2/service
 
-This is a GraphQL endpoint which handles both query and mutation.
+This is a GraphQL endpoint which handles both query and mutation requests.
 
 The GraphQL schema is as follows:
 
 ```
 ```
 
-An example of HTTP request fetching source migrations with filters, all applied migrations for specific schema, and all tenants in a single query is show below:
+## /v1 - deprecated available in v4.x and v2020.x
 
-```
+API v1 is available in migrator v4.x and v2020.x.
 
-```
-
-## /v1 **deprecated in v2020.1.0, sunset in next major release**
-
-API v1 was introduced in migrator v4.0. Any non API-breaking changes will be added to v1. Any significant change or an API-breaking change will be added to API v2.
-
-As of migrator v2020.1.0 this API is deprecated and will be sunset in the next major release.
+Important: As of migrator v2020.1.0 this API is deprecated and will sunset in the next major release - v2021.1.0).
 
 ## GET /v1/config
 

--- a/coordinator/coordinator.go
+++ b/coordinator/coordinator.go
@@ -15,7 +15,7 @@ import (
 
 // Coordinator interface abstracts all operations performed by migrator
 type Coordinator interface {
-	GetTenants() []string
+	GetTenants() []types.Tenant
 	GetSourceMigrations() []types.Migration
 	GetAppliedMigrations() []types.MigrationDB
 	VerifySourceMigrationsCheckSums() (bool, []types.Migration)
@@ -31,7 +31,7 @@ type coordinator struct {
 	loader            loader.Loader
 	notifier          notifications.Notifier
 	config            *config.Config
-	tenants           []string
+	tenants           []types.Tenant
 	sourceMigrations  []types.Migration
 	appliedMigrations []types.MigrationDB
 	loaderLock        sync.Mutex
@@ -56,7 +56,7 @@ func New(ctx context.Context, config *config.Config, newConnector db.Factory, ne
 	return coordinator
 }
 
-func (c *coordinator) GetTenants() []string {
+func (c *coordinator) GetTenants() []types.Tenant {
 	c.connectorLock.Lock()
 	defer c.connectorLock.Unlock()
 	if c.tenants == nil {

--- a/coordinator/coordinator_mocks.go
+++ b/coordinator/coordinator_mocks.go
@@ -69,8 +69,11 @@ func (m *mockedConnector) AddTenantAndApplyMigrations(types.MigrationsModeType, 
 	return &types.MigrationResults{}
 }
 
-func (m *mockedConnector) GetTenants() []string {
-	return []string{"a", "b", "c"}
+func (m *mockedConnector) GetTenants() []types.Tenant {
+	a := types.Tenant{Name: "a"}
+	b := types.Tenant{Name: "b"}
+	c := types.Tenant{Name: "c"}
+	return []types.Tenant{a, b, c}
 }
 
 func (m *mockedConnector) GetAppliedMigrations() []types.MigrationDB {

--- a/coordinator/coordinator_mocks.go
+++ b/coordinator/coordinator_mocks.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"time"
 
+	"github.com/graph-gophers/graphql-go"
+
 	"github.com/lukaszbudnik/migrator/config"
 	"github.com/lukaszbudnik/migrator/db"
 	"github.com/lukaszbudnik/migrator/loader"
@@ -79,7 +81,7 @@ func (m *mockedConnector) GetTenants() []types.Tenant {
 func (m *mockedConnector) GetAppliedMigrations() []types.MigrationDB {
 	m1 := types.Migration{Name: "201602220000.sql", SourceDir: "source", File: "source/201602220000.sql", MigrationType: types.MigrationTypeSingleMigration, Contents: "select abc"}
 	d1 := time.Date(2016, 02, 22, 16, 41, 1, 123, time.UTC)
-	ms := []types.MigrationDB{{Migration: m1, Schema: "source", AppliedAt: d1}}
+	ms := []types.MigrationDB{{Migration: m1, Schema: "source", AppliedAt: graphql.Time{Time: d1}}}
 	return ms
 }
 
@@ -100,7 +102,7 @@ func (m *mockedDifferentScriptCheckSumMockedConnector) GetAppliedMigrations() []
 	d1 := time.Date(2016, 02, 22, 16, 41, 1, 123, time.UTC)
 	m2 := types.Migration{Name: "recreate-indexes.sql", SourceDir: "tenants-scripts", File: "tenants-scripts/recreate-indexes.sql", MigrationType: types.MigrationTypeTenantScript, Contents: "select abc", CheckSum: "sha256-2"}
 	d2 := time.Date(2016, 02, 22, 16, 41, 1, 456, time.UTC)
-	ms := []types.MigrationDB{{Migration: m1, Schema: "source", AppliedAt: d1}, {Migration: m2, Schema: "customer1", AppliedAt: d2}}
+	ms := []types.MigrationDB{{Migration: m1, Schema: "source", AppliedAt: graphql.Time{Time: d1}}, {Migration: m2, Schema: "customer1", AppliedAt: graphql.Time{Time: d2}}}
 	return ms
 }
 

--- a/coordinator/coordinator_test.go
+++ b/coordinator/coordinator_test.go
@@ -257,5 +257,8 @@ func TestGetTenants(t *testing.T) {
 	coordinator := New(context.TODO(), nil, newMockedConnector, newMockedDiskLoader, newMockedNotifier)
 	defer coordinator.Dispose()
 	tenants := coordinator.GetTenants()
-	assert.Equal(t, []string{"a", "b", "c"}, tenants)
+	a := types.Tenant{Name: "a"}
+	b := types.Tenant{Name: "b"}
+	c := types.Tenant{Name: "c"}
+	assert.Equal(t, []types.Tenant{a, b, c}, tenants)
 }

--- a/coordinator/coordinator_test.go
+++ b/coordinator/coordinator_test.go
@@ -5,21 +5,23 @@ import (
 	"testing"
 	"time"
 
-	"github.com/lukaszbudnik/migrator/types"
+	"github.com/graph-gophers/graphql-go"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/lukaszbudnik/migrator/types"
 )
 
 func TestMigrationsFlattenMigrationDBs1(t *testing.T) {
 	m1 := types.Migration{Name: "001.sql", SourceDir: "public", File: "public/001.sql", MigrationType: types.MigrationTypeSingleMigration}
-	db1 := types.MigrationDB{Migration: m1, Schema: "public", AppliedAt: time.Now()}
+	db1 := types.MigrationDB{Migration: m1, Schema: "public", AppliedAt: graphql.Time{Time: time.Now()}}
 
 	m2 := types.Migration{Name: "002.sql", SourceDir: "tenants", File: "tenants/002.sql", MigrationType: types.MigrationTypeTenantMigration}
-	db2 := types.MigrationDB{Migration: m2, Schema: "abc", AppliedAt: time.Now()}
+	db2 := types.MigrationDB{Migration: m2, Schema: "abc", AppliedAt: graphql.Time{Time: time.Now()}}
 
-	db3 := types.MigrationDB{Migration: m2, Schema: "def", AppliedAt: time.Now()}
+	db3 := types.MigrationDB{Migration: m2, Schema: "def", AppliedAt: graphql.Time{Time: time.Now()}}
 
 	m4 := types.Migration{Name: "003.sql", SourceDir: "ref", File: "ref/003.sql", MigrationType: types.MigrationTypeSingleMigration}
-	db4 := types.MigrationDB{Migration: m4, Schema: "ref", AppliedAt: time.Now()}
+	db4 := types.MigrationDB{Migration: m4, Schema: "ref", AppliedAt: graphql.Time{Time: time.Now()}}
 
 	dbs := []types.MigrationDB{db1, db2, db3, db4}
 
@@ -35,12 +37,12 @@ func TestMigrationsFlattenMigrationDBs1(t *testing.T) {
 
 func TestMigrationsFlattenMigrationDBs2(t *testing.T) {
 	m2 := types.Migration{Name: "002.sql", SourceDir: "tenants", File: "tenants/002.sql", MigrationType: types.MigrationTypeTenantMigration}
-	db2 := types.MigrationDB{Migration: m2, Schema: "abc", AppliedAt: time.Now()}
+	db2 := types.MigrationDB{Migration: m2, Schema: "abc", AppliedAt: graphql.Time{Time: time.Now()}}
 
-	db3 := types.MigrationDB{Migration: m2, Schema: "def", AppliedAt: time.Now()}
+	db3 := types.MigrationDB{Migration: m2, Schema: "def", AppliedAt: graphql.Time{Time: time.Now()}}
 
 	m4 := types.Migration{Name: "003.sql", SourceDir: "ref", File: "ref/003.sql", MigrationType: types.MigrationTypeSingleMigration}
-	db4 := types.MigrationDB{Migration: m4, Schema: "ref", AppliedAt: time.Now()}
+	db4 := types.MigrationDB{Migration: m4, Schema: "ref", AppliedAt: graphql.Time{Time: time.Now()}}
 
 	dbs := []types.MigrationDB{db2, db3, db4}
 
@@ -52,26 +54,26 @@ func TestMigrationsFlattenMigrationDBs2(t *testing.T) {
 
 func TestMigrationsFlattenMigrationDBs3(t *testing.T) {
 	m1 := types.Migration{Name: "001.sql", SourceDir: "public", File: "public/001.sql", MigrationType: types.MigrationTypeSingleMigration}
-	db1 := types.MigrationDB{Migration: m1, Schema: "public", AppliedAt: time.Now()}
+	db1 := types.MigrationDB{Migration: m1, Schema: "public", AppliedAt: graphql.Time{Time: time.Now()}}
 
 	m2 := types.Migration{Name: "002.sql", SourceDir: "tenants", File: "tenants/002.sql", MigrationType: types.MigrationTypeTenantMigration}
-	db2 := types.MigrationDB{Migration: m2, Schema: "abc", AppliedAt: time.Now()}
+	db2 := types.MigrationDB{Migration: m2, Schema: "abc", AppliedAt: graphql.Time{Time: time.Now()}}
 
-	db3 := types.MigrationDB{Migration: m2, Schema: "def", AppliedAt: time.Now()}
+	db3 := types.MigrationDB{Migration: m2, Schema: "def", AppliedAt: graphql.Time{Time: time.Now()}}
 
 	m4 := types.Migration{Name: "003.sql", SourceDir: "ref", File: "ref/003.sql", MigrationType: types.MigrationTypeSingleMigration}
-	db4 := types.MigrationDB{Migration: m4, Schema: "ref", AppliedAt: time.Now()}
+	db4 := types.MigrationDB{Migration: m4, Schema: "ref", AppliedAt: graphql.Time{Time: time.Now()}}
 
 	m5 := types.Migration{Name: "global-stored-procedure1.sql", SourceDir: "public", File: "public-scripts/global-stored-procedure1.sql", MigrationType: types.MigrationTypeSingleScript}
-	db5 := types.MigrationDB{Migration: m5, Schema: "public", AppliedAt: time.Now()}
+	db5 := types.MigrationDB{Migration: m5, Schema: "public", AppliedAt: graphql.Time{Time: time.Now()}}
 
 	m6 := types.Migration{Name: "global-stored-procedure2.sql", SourceDir: "public", File: "public-scripts/global-stored-procedure2sql", MigrationType: types.MigrationTypeSingleScript}
-	db6 := types.MigrationDB{Migration: m6, Schema: "public", AppliedAt: time.Now()}
+	db6 := types.MigrationDB{Migration: m6, Schema: "public", AppliedAt: graphql.Time{Time: time.Now()}}
 
 	m7 := types.Migration{Name: "002.sql", SourceDir: "tenants-scripts", File: "tenants/002.sql", MigrationType: types.MigrationTypeTenantMigration}
-	db7 := types.MigrationDB{Migration: m7, Schema: "abc", AppliedAt: time.Now()}
+	db7 := types.MigrationDB{Migration: m7, Schema: "abc", AppliedAt: graphql.Time{Time: time.Now()}}
 
-	db8 := types.MigrationDB{Migration: m7, Schema: "def", AppliedAt: time.Now()}
+	db8 := types.MigrationDB{Migration: m7, Schema: "def", AppliedAt: graphql.Time{Time: time.Now()}}
 
 	dbs := []types.MigrationDB{db1, db2, db3, db4, db5, db6, db7, db8}
 
@@ -91,7 +93,7 @@ func TestComputeMigrationsToApply(t *testing.T) {
 	mdef7 := types.Migration{Name: "g", SourceDir: "g", File: "g", MigrationType: types.MigrationTypeTenantScript}
 
 	diskMigrations := []types.Migration{mdef1, mdef2, mdef3, mdef4, mdef5, mdef6, mdef7}
-	dbMigrations := []types.MigrationDB{{Migration: mdef1, Schema: "a", AppliedAt: time.Now()}, {Migration: mdef2, Schema: "abc", AppliedAt: time.Now()}, {Migration: mdef2, Schema: "def", AppliedAt: time.Now()}, {Migration: mdef5, Schema: "e", AppliedAt: time.Now()}, {Migration: mdef6, Schema: "f", AppliedAt: time.Now()}, {Migration: mdef7, Schema: "abc", AppliedAt: time.Now()}, {Migration: mdef7, Schema: "def", AppliedAt: time.Now()}}
+	dbMigrations := []types.MigrationDB{{Migration: mdef1, Schema: "a", AppliedAt: graphql.Time{Time: time.Now()}}, {Migration: mdef2, Schema: "abc", AppliedAt: graphql.Time{Time: time.Now()}}, {Migration: mdef2, Schema: "def", AppliedAt: graphql.Time{Time: time.Now()}}, {Migration: mdef5, Schema: "e", AppliedAt: graphql.Time{Time: time.Now()}}, {Migration: mdef6, Schema: "f", AppliedAt: graphql.Time{Time: time.Now()}}, {Migration: mdef7, Schema: "abc", AppliedAt: graphql.Time{Time: time.Now()}}, {Migration: mdef7, Schema: "def", AppliedAt: graphql.Time{Time: time.Now()}}}
 
 	coordinator := &coordinator{
 		ctx:       context.TODO(),
@@ -135,7 +137,7 @@ func TestComputeMigrationsToApplyDifferentTimestamps(t *testing.T) {
 	dev2p := types.Migration{Name: "20181120", SourceDir: "public", File: "public/20181120", MigrationType: types.MigrationTypeSingleMigration}
 
 	diskMigrations := []types.Migration{mdef1, mdef2, mdef3, dev1, dev1p1, dev1p2, dev2, dev2p}
-	dbMigrations := []types.MigrationDB{{Migration: mdef1, Schema: "abc", AppliedAt: time.Now()}, {Migration: mdef1, Schema: "def", AppliedAt: time.Now()}, {Migration: mdef2, Schema: "public", AppliedAt: time.Now()}, {Migration: mdef3, Schema: "public", AppliedAt: time.Now()}, {Migration: dev2, Schema: "abc", AppliedAt: time.Now()}, {Migration: dev2, Schema: "def", AppliedAt: time.Now()}, {Migration: dev2p, Schema: "public", AppliedAt: time.Now()}}
+	dbMigrations := []types.MigrationDB{{Migration: mdef1, Schema: "abc", AppliedAt: graphql.Time{Time: time.Now()}}, {Migration: mdef1, Schema: "def", AppliedAt: graphql.Time{Time: time.Now()}}, {Migration: mdef2, Schema: "public", AppliedAt: graphql.Time{Time: time.Now()}}, {Migration: mdef3, Schema: "public", AppliedAt: graphql.Time{Time: time.Now()}}, {Migration: dev2, Schema: "abc", AppliedAt: graphql.Time{Time: time.Now()}}, {Migration: dev2, Schema: "def", AppliedAt: graphql.Time{Time: time.Now()}}, {Migration: dev2p, Schema: "public", AppliedAt: graphql.Time{Time: time.Now()}}}
 
 	coordinator := &coordinator{
 		ctx:       context.TODO(),

--- a/data/graphql.go
+++ b/data/graphql.go
@@ -28,10 +28,17 @@ const schemaString = `
   	contents: String!
     checkSum: String!
   }
-  scalar MigrationType
-  scalar MigrationTypeOptional
+  enum MigrationType {
+    SingleMigration
+    TenantMigration
+    SingleScript
+    TenantScript
+  }
+  type Tenant {
+    name: String!
+  }
 	type Query {
-    sourceMigrations(name: String, sourceDir: String, file: String, migrationType: MigrationTypeOptional): [SourceMigration!]!
+    sourceMigrations(name: String, sourceDir: String, file: String, migrationType: MigrationType): [SourceMigration!]!
     sourceMigration(file: String!): SourceMigration!
 	}
 `
@@ -40,7 +47,7 @@ type sourceMigrationsFilters struct {
 	Name          *string
 	SourceDir     *string
 	File          *string
-	MigrationType *types.MigrationTypeOptional
+	MigrationType *types.MigrationType
 }
 
 type RootResolver struct {

--- a/data/graphql.go
+++ b/data/graphql.go
@@ -1,0 +1,99 @@
+package data
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/lukaszbudnik/migrator/loader"
+	"github.com/lukaszbudnik/migrator/types"
+)
+
+const schemaString = `
+	schema {
+		query: Query
+	}
+	interface Migration {
+		name: String!
+		migrationType: MigrationType!
+    sourceDir: String!
+  	file: String!
+  	contents: String!
+    checkSum: String!
+	}
+  type SourceMigration implements Migration {
+    name: String!
+    migrationType: MigrationType!
+    sourceDir: String!
+  	file: String!
+  	contents: String!
+    checkSum: String!
+  }
+  scalar MigrationType
+  scalar MigrationTypeOptional
+	type Query {
+    sourceMigrations(name: String, sourceDir: String, file: String, migrationType: MigrationTypeOptional): [SourceMigration!]!
+    sourceMigration(file: String!): SourceMigration!
+	}
+`
+
+type sourceMigrationsFilters struct {
+	Name          *string
+	SourceDir     *string
+	File          *string
+	MigrationType *types.MigrationTypeOptional
+}
+
+type RootResolver struct {
+	loader loader.Loader
+}
+
+func (r *RootResolver) SourceMigrations(args sourceMigrationsFilters) ([]types.Migration, error) {
+	allSourceMigrations := r.loader.GetSourceMigrations()
+	filteredMigrations := r.filterMigrations(allSourceMigrations, args)
+	return filteredMigrations, nil
+}
+
+func (r *RootResolver) SourceMigration(args struct {
+	File string
+}) (types.Migration, error) {
+	filter := sourceMigrationsFilters{File: &args.File}
+	allSourceMigrations := r.loader.GetSourceMigrations()
+	filteredMigrations := r.filterMigrations(allSourceMigrations, filter)
+	if len(filteredMigrations) == 0 {
+		return types.Migration{}, fmt.Errorf("Source migration %q not found", args.File)
+	}
+	return filteredMigrations[0], nil
+}
+
+func (r *RootResolver) filterMigrations(migrations []types.Migration, args sourceMigrationsFilters) []types.Migration {
+	filtered := []types.Migration{}
+	ps := reflect.ValueOf(&args)
+	s := ps.Elem()
+	for _, m := range migrations {
+		match := true
+		for i := 0; i < s.Type().NumField(); i++ {
+			// if filter is nil it means match
+			if s.Field(i).IsNil() {
+				continue
+			}
+			// args field names match migration names
+			pm := reflect.ValueOf(m).FieldByName(s.Type().Field(i).Name)
+
+			// custom Scalar types are mapped to struct wrappers (so that pointers work correctly during unmarshalling)
+			if s.Field(i).Elem().Type().Kind() == reflect.Struct {
+				match = match && (pm.Interface() == s.Field(i).Elem().Field(0).Interface())
+			} else {
+				// other Scalar types are compared directly
+				match = match && (pm.Interface() == s.Field(i).Elem().Interface())
+			}
+			// if already non match don't bother further looping
+			if !match {
+				continue
+			}
+		}
+		if match {
+			filtered = append(filtered, m)
+		}
+	}
+	return filtered
+}

--- a/data/graphql.go
+++ b/data/graphql.go
@@ -29,18 +29,31 @@ const SchemaDefinition = `
   	contents: String!
     checkSum: String!
   }
+  type DBMigration implements Migration {
+    name: String!
+    migrationType: MigrationType!
+    sourceDir: String!
+    file: String!
+    contents: String!
+    checkSum: String!
+    schema: String!
+    appliedAt: Time!
+  }
   enum MigrationType {
     SingleMigration
     TenantMigration
     SingleScript
     TenantScript
   }
+  scalar Time
   type Tenant {
     name: String!
   }
 	type Query {
     sourceMigrations(name: String, sourceDir: String, file: String, migrationType: MigrationType): [SourceMigration!]!
     sourceMigration(file: String!): SourceMigration!
+    dbMigrations(name: String, sourceDir: String, file: String, migrationType: MigrationType, schema: String): [DBMigration!]!
+    dbMigration(file: String!, schema: String!): DBMigration!
     tenants(): [Tenant!]!
 	}
 `
@@ -50,6 +63,11 @@ type sourceMigrationsFilters struct {
 	SourceDir     *string
 	File          *string
 	MigrationType *types.MigrationType
+}
+
+type dbMigrationsFilters struct {
+	sourceMigrationsFilters
+	Schema *string
 }
 
 // RootResolver is resolver for all the migrator data
@@ -62,53 +80,109 @@ func (r *RootResolver) Tenants() ([]types.Tenant, error) {
 	return tenants, nil
 }
 
-func (r *RootResolver) SourceMigrations(args sourceMigrationsFilters) ([]types.Migration, error) {
+func (r *RootResolver) SourceMigrations(filters sourceMigrationsFilters) ([]types.Migration, error) {
 	allSourceMigrations := r.Coordinator.GetSourceMigrations()
-	filteredMigrations := r.filterMigrations(allSourceMigrations, args)
+	filteredMigrations := r.filterMigrations(allSourceMigrations, filters)
 	return filteredMigrations, nil
 }
 
 func (r *RootResolver) SourceMigration(args struct {
 	File string
 }) (types.Migration, error) {
-	filter := sourceMigrationsFilters{File: &args.File}
+	filters := sourceMigrationsFilters{File: &args.File}
 	allSourceMigrations := r.Coordinator.GetSourceMigrations()
-	filteredMigrations := r.filterMigrations(allSourceMigrations, filter)
+	filteredMigrations := r.filterMigrations(allSourceMigrations, filters)
 	if len(filteredMigrations) == 0 {
 		return types.Migration{}, fmt.Errorf("Source migration %q not found", args.File)
 	}
 	return filteredMigrations[0], nil
 }
 
-func (r *RootResolver) filterMigrations(migrations []types.Migration, args sourceMigrationsFilters) []types.Migration {
-	filtered := []types.Migration{}
-	ps := reflect.ValueOf(&args)
-	s := ps.Elem()
-	for _, m := range migrations {
-		match := true
-		for i := 0; i < s.Type().NumField(); i++ {
-			// if filter is nil it means match
-			if s.Field(i).IsNil() {
-				continue
-			}
-			// args field names match migration names
-			pm := reflect.ValueOf(m).FieldByName(s.Type().Field(i).Name)
+func (r *RootResolver) DBMigrations(filters dbMigrationsFilters) ([]types.MigrationDB, error) {
+	dbMigrations := r.Coordinator.GetAppliedMigrations()
+	filteredMigrations := r.filterDBMigrations(dbMigrations, filters)
+	return filteredMigrations, nil
+}
 
-			// custom Scalar types are mapped to struct wrappers (so that pointers work correctly during unmarshalling)
-			if s.Field(i).Elem().Type().Kind() == reflect.Struct {
-				match = match && (pm.Interface() == s.Field(i).Elem().Field(0).Interface())
-			} else {
-				// other Scalar types are compared directly
-				match = match && (pm.Interface() == s.Field(i).Elem().Interface())
-			}
-			// if already non match don't bother further looping
-			if !match {
-				continue
-			}
-		}
+func (r *RootResolver) DBMigration(args struct {
+	File   string
+	Schema string
+}) (types.MigrationDB, error) {
+	filters := dbMigrationsFilters{sourceMigrationsFilters: sourceMigrationsFilters{File: &args.File}, Schema: &args.Schema}
+	dbMigrations := r.Coordinator.GetAppliedMigrations()
+	filteredMigrations := r.filterDBMigrations(dbMigrations, filters)
+	if len(filteredMigrations) == 0 {
+		return types.MigrationDB{}, fmt.Errorf("Source migration %q not found", args.File)
+	}
+	return filteredMigrations[0], nil
+}
+
+func (r *RootResolver) filterMigrations(migrations []types.Migration, filters sourceMigrationsFilters) []types.Migration {
+	filtered := []types.Migration{}
+	for _, m := range migrations {
+		match := r.matchMigration(m, filters)
 		if match {
 			filtered = append(filtered, m)
 		}
 	}
 	return filtered
+}
+
+func (r *RootResolver) filterDBMigrations(migrations []types.MigrationDB, filters dbMigrationsFilters) []types.MigrationDB {
+	filtered := []types.MigrationDB{}
+	for _, m := range migrations {
+		match := r.matchDBMigration(m, filters)
+		if match {
+			filtered = append(filtered, m)
+		}
+	}
+	return filtered
+}
+
+func (r *RootResolver) matchMigration(m types.Migration, filters sourceMigrationsFilters) bool {
+	ps := reflect.ValueOf(&filters)
+	s := ps.Elem()
+	match := true
+	for i := 0; i < s.Type().NumField(); i++ {
+		// if filter is nil it means match
+		if s.Field(i).IsNil() {
+			continue
+		}
+		// args field names match migration names
+		pm := reflect.ValueOf(m).FieldByName(s.Type().Field(i).Name)
+		match = match && (pm.Interface() == s.Field(i).Elem().Interface())
+		// if already non match don't bother further looping
+		if !match {
+			continue
+		}
+	}
+	return match
+}
+
+func (r *RootResolver) matchDBMigration(m types.MigrationDB, filters dbMigrationsFilters) bool {
+	match := r.matchMigration(m.Migration, filters.sourceMigrationsFilters)
+	// if Migration is already different don't bother checking MigrationDB fields
+	if !match {
+		return match
+	}
+	ps := reflect.ValueOf(&filters)
+	s := ps.Elem()
+	for i := 0; i < s.Type().NumField(); i++ {
+		// skip embedded struct - already handled by matchMigration()
+		if s.Field(i).Kind() == reflect.Struct {
+			continue
+		}
+		// if filter is nil it means match
+		if s.Field(i).IsNil() {
+			continue
+		}
+		// args field names match migration names
+		pm := reflect.ValueOf(m).FieldByName(s.Type().Field(i).Name)
+		match = match && (pm.Interface() == s.Field(i).Elem().Interface())
+		// if already non match don't bother further looping
+		if !match {
+			break
+		}
+	}
+	return match
 }

--- a/data/graphql_mocks.go
+++ b/data/graphql_mocks.go
@@ -1,0 +1,34 @@
+package data
+
+import (
+	"github.com/lukaszbudnik/migrator/types"
+)
+
+type mockedLoader struct {
+}
+
+func (m *mockedLoader) GetSourceMigrations() []types.Migration {
+
+	// 5 migrations in total
+	// 4 migrations with type MigrationTypeSingleMigration
+	// 3 migrations with sourceDir source and type MigrationTypeSingleMigration
+	// 2 migrations with name 201602220001.sql and type MigrationTypeSingleMigration
+	// 1 migration with file config/201602220001.sql
+
+	m1 := types.Migration{Name: "201602220000.sql", SourceDir: "source", File: "source/201602220000.sql", MigrationType: types.MigrationTypeSingleMigration, Contents: "select abc"}
+	m2 := types.Migration{Name: "201602220001.sql", SourceDir: "source", File: "source/201602220001.sql", MigrationType: types.MigrationTypeSingleMigration, Contents: "select def"}
+	m3 := types.Migration{Name: "201602220001.sql", SourceDir: "config", File: "config/201602220001.sql", MigrationType: types.MigrationTypeSingleMigration, Contents: "select def"}
+	m4 := types.Migration{Name: "201602220002.sql", SourceDir: "source", File: "source/201602220002.sql", MigrationType: types.MigrationTypeSingleMigration, Contents: "select def"}
+	m5 := types.Migration{Name: "201602220003.sql", SourceDir: "tenant", File: "tenant/201602220003.sql", MigrationType: types.MigrationTypeTenantMigration, Contents: "select def"}
+	return []types.Migration{m1, m2, m3, m4, m5}
+}
+
+// func (m *mockedCoordinator) GetAppliedMigrations() []types.MigrationDB {
+// 	m1 := types.Migration{Name: "201602220000.sql", SourceDir: "source", File: "source/201602220000.sql", MigrationType: types.MigrationTypeSingleMigration, Contents: "select abc", CheckSum: "sha256"}
+// 	d1 := time.Date(2016, 02, 22, 16, 41, 1, 123, time.UTC)
+// 	ms := []types.MigrationDB{{Migration: m1, Schema: "source", AppliedAt: d1}}
+// 	return ms
+// }
+// func (m *mockedCoordinator) GetTenants() []string {
+// 	return []string{"a", "b", "c"}
+// }

--- a/data/graphql_mocks.go
+++ b/data/graphql_mocks.go
@@ -3,6 +3,7 @@ package data
 import (
 	"time"
 
+	"github.com/graph-gophers/graphql-go"
 	"github.com/lukaszbudnik/migrator/types"
 )
 
@@ -38,8 +39,19 @@ func (m *mockedCoordinator) GetTenants() []types.Tenant {
 func (m *mockedCoordinator) GetAppliedMigrations() []types.MigrationDB {
 	m1 := types.Migration{Name: "201602220000.sql", SourceDir: "source", File: "source/201602220000.sql", MigrationType: types.MigrationTypeSingleMigration, Contents: "select abc"}
 	d1 := time.Date(2016, 02, 22, 16, 41, 1, 123, time.UTC)
-	ms := []types.MigrationDB{{Migration: m1, Schema: "source", AppliedAt: d1}}
-	return ms
+	db1 := types.MigrationDB{Migration: m1, Schema: "source", AppliedAt: graphql.Time{Time: d1}}
+
+	m2 := types.Migration{Name: "202002180000.sql", SourceDir: "config", File: "config/202002180000.sql", MigrationType: types.MigrationTypeSingleMigration, Contents: "select abc"}
+	d2 := time.Date(2020, 02, 18, 16, 41, 1, 123, time.UTC)
+	db2 := types.MigrationDB{Migration: m2, Schema: "source", AppliedAt: graphql.Time{Time: d2}}
+
+	m3 := types.Migration{Name: "202002180000.sql", SourceDir: "tenants", File: "tenants/202002180000.sql", MigrationType: types.MigrationTypeTenantMigration, Contents: "select abc"}
+	d3 := time.Date(2020, 02, 18, 16, 41, 1, 123, time.UTC)
+	db3 := types.MigrationDB{Migration: m3, Schema: "abc", AppliedAt: graphql.Time{Time: d3}}
+	db4 := types.MigrationDB{Migration: m3, Schema: "def", AppliedAt: graphql.Time{Time: d3}}
+	db5 := types.MigrationDB{Migration: m3, Schema: "xyz", AppliedAt: graphql.Time{Time: d3}}
+
+	return []types.MigrationDB{db1, db2, db3, db4, db5}
 }
 
 func (m *mockedCoordinator) ApplyMigrations(types.MigrationsModeType) (*types.MigrationResults, []types.Migration) {

--- a/data/graphql_mocks.go
+++ b/data/graphql_mocks.go
@@ -1,13 +1,15 @@
 package data
 
 import (
+	"time"
+
 	"github.com/lukaszbudnik/migrator/types"
 )
 
-type mockedLoader struct {
+type mockedCoordinator struct {
 }
 
-func (m *mockedLoader) GetSourceMigrations() []types.Migration {
+func (m *mockedCoordinator) GetSourceMigrations() []types.Migration {
 
 	// 5 migrations in total
 	// 4 migrations with type MigrationTypeSingleMigration
@@ -23,12 +25,31 @@ func (m *mockedLoader) GetSourceMigrations() []types.Migration {
 	return []types.Migration{m1, m2, m3, m4, m5}
 }
 
-// func (m *mockedCoordinator) GetAppliedMigrations() []types.MigrationDB {
-// 	m1 := types.Migration{Name: "201602220000.sql", SourceDir: "source", File: "source/201602220000.sql", MigrationType: types.MigrationTypeSingleMigration, Contents: "select abc", CheckSum: "sha256"}
-// 	d1 := time.Date(2016, 02, 22, 16, 41, 1, 123, time.UTC)
-// 	ms := []types.MigrationDB{{Migration: m1, Schema: "source", AppliedAt: d1}}
-// 	return ms
-// }
-// func (m *mockedCoordinator) GetTenants() []string {
-// 	return []string{"a", "b", "c"}
-// }
+func (m *mockedCoordinator) Dispose() {
+}
+
+func (m *mockedCoordinator) GetTenants() []types.Tenant {
+	a := types.Tenant{Name: "a"}
+	b := types.Tenant{Name: "b"}
+	c := types.Tenant{Name: "c"}
+	return []types.Tenant{a, b, c}
+}
+
+func (m *mockedCoordinator) GetAppliedMigrations() []types.MigrationDB {
+	m1 := types.Migration{Name: "201602220000.sql", SourceDir: "source", File: "source/201602220000.sql", MigrationType: types.MigrationTypeSingleMigration, Contents: "select abc"}
+	d1 := time.Date(2016, 02, 22, 16, 41, 1, 123, time.UTC)
+	ms := []types.MigrationDB{{Migration: m1, Schema: "source", AppliedAt: d1}}
+	return ms
+}
+
+func (m *mockedCoordinator) ApplyMigrations(types.MigrationsModeType) (*types.MigrationResults, []types.Migration) {
+	return &types.MigrationResults{}, []types.Migration{}
+}
+
+func (m *mockedCoordinator) AddTenantAndApplyMigrations(types.MigrationsModeType, string) (*types.MigrationResults, []types.Migration) {
+	return &types.MigrationResults{}, []types.Migration{}
+}
+
+func (m *mockedCoordinator) VerifySourceMigrationsCheckSums() (bool, []types.Migration) {
+	return true, nil
+}

--- a/data/graphql_test.go
+++ b/data/graphql_test.go
@@ -10,12 +10,34 @@ import (
 	graphql "github.com/graph-gophers/graphql-go"
 )
 
+func TestTenants(t *testing.T) {
+	ctx := context.Background()
+
+	opts := []graphql.SchemaOpt{graphql.UseFieldResolvers()}
+	schema := graphql.MustParseSchema(SchemaDefinition, &RootResolver{Coordinator: &mockedCoordinator{}}, opts...)
+
+	opName := "Tenants"
+	query := `query Tenants {
+      tenants {
+        name
+      }
+    }`
+	variables := map[string]interface{}{}
+
+	resp := schema.Exec(ctx, query, opName, variables)
+	jsonMap := make(map[string]interface{})
+	err := json.Unmarshal(resp.Data, &jsonMap)
+	assert.Nil(t, err)
+	results := len(jsonMap["tenants"].([]interface{}))
+	assert.Equal(t, 3, results)
+}
+
 func TestSourceMigrationsNoFilters(t *testing.T) {
 
 	ctx := context.Background()
 
 	opts := []graphql.SchemaOpt{graphql.UseFieldResolvers()}
-	schema := graphql.MustParseSchema(schemaString, &RootResolver{loader: &mockedLoader{}}, opts...)
+	schema := graphql.MustParseSchema(SchemaDefinition, &RootResolver{Coordinator: &mockedCoordinator{}}, opts...)
 
 	opName := "SourceMigrations"
 	query := `query SourceMigrations {
@@ -43,7 +65,7 @@ func TestSourceMigrationsTypeFilter(t *testing.T) {
 	ctx := context.Background()
 
 	opts := []graphql.SchemaOpt{graphql.UseFieldResolvers()}
-	schema := graphql.MustParseSchema(schemaString, &RootResolver{loader: &mockedLoader{}}, opts...)
+	schema := graphql.MustParseSchema(SchemaDefinition, &RootResolver{Coordinator: &mockedCoordinator{}}, opts...)
 
 	opName := "SourceMigrations"
 	query := `query SourceMigrations($migrationType: MigrationType) {
@@ -72,7 +94,7 @@ func TestSourceMigrationsTypeSourceDirFilter(t *testing.T) {
 	ctx := context.Background()
 
 	opts := []graphql.SchemaOpt{graphql.UseFieldResolvers()}
-	schema := graphql.MustParseSchema(schemaString, &RootResolver{loader: &mockedLoader{}}, opts...)
+	schema := graphql.MustParseSchema(SchemaDefinition, &RootResolver{Coordinator: &mockedCoordinator{}}, opts...)
 
 	opName := "SourceMigrations"
 	query := `query SourceMigrations($sourceDir: String, $migrationType: MigrationType) {
@@ -102,7 +124,7 @@ func TestSourceMigrationsTypeSourceDirNameFilter(t *testing.T) {
 	ctx := context.Background()
 
 	opts := []graphql.SchemaOpt{graphql.UseFieldResolvers()}
-	schema := graphql.MustParseSchema(schemaString, &RootResolver{loader: &mockedLoader{}}, opts...)
+	schema := graphql.MustParseSchema(SchemaDefinition, &RootResolver{Coordinator: &mockedCoordinator{}}, opts...)
 
 	opName := "SourceMigrations"
 	query := `query SourceMigrations($name: String, $migrationType: MigrationType) {
@@ -132,7 +154,7 @@ func TestSourceMigrationsTypeNameFilter(t *testing.T) {
 	ctx := context.Background()
 
 	opts := []graphql.SchemaOpt{graphql.UseFieldResolvers()}
-	schema := graphql.MustParseSchema(schemaString, &RootResolver{loader: &mockedLoader{}}, opts...)
+	schema := graphql.MustParseSchema(SchemaDefinition, &RootResolver{Coordinator: &mockedCoordinator{}}, opts...)
 
 	opName := "SourceMigrations"
 	query := `query SourceMigrations($file: String) {
@@ -161,7 +183,7 @@ func TestSourceMigration(t *testing.T) {
 	ctx := context.Background()
 
 	opts := []graphql.SchemaOpt{graphql.UseFieldResolvers()}
-	schema := graphql.MustParseSchema(schemaString, &RootResolver{loader: &mockedLoader{}}, opts...)
+	schema := graphql.MustParseSchema(SchemaDefinition, &RootResolver{Coordinator: &mockedCoordinator{}}, opts...)
 
 	opName := "SourceMigration"
 	query := `query SourceMigration($file: String!) {
@@ -190,7 +212,7 @@ func TestSourceMigrations2Queries(t *testing.T) {
 	ctx := context.Background()
 
 	opts := []graphql.SchemaOpt{graphql.UseFieldResolvers()}
-	schema := graphql.MustParseSchema(schemaString, &RootResolver{loader: &mockedLoader{}}, opts...)
+	schema := graphql.MustParseSchema(SchemaDefinition, &RootResolver{Coordinator: &mockedCoordinator{}}, opts...)
 
 	opName := "SourceMigrations"
 	query := `query SourceMigrations($singleMigrationType: MigrationType, $tenantMigrationType: MigrationType) {

--- a/data/graphql_test.go
+++ b/data/graphql_test.go
@@ -46,7 +46,7 @@ func TestSourceMigrationsTypeFilter(t *testing.T) {
 	schema := graphql.MustParseSchema(schemaString, &RootResolver{loader: &mockedLoader{}}, opts...)
 
 	opName := "SourceMigrations"
-	query := `query SourceMigrations($migrationType: MigrationTypeOptional) {
+	query := `query SourceMigrations($migrationType: MigrationType) {
 	    sourceMigrations(migrationType: $migrationType) {
 	      name,
 	      migrationType,
@@ -57,7 +57,7 @@ func TestSourceMigrationsTypeFilter(t *testing.T) {
 	    }
   }`
 	variables := map[string]interface{}{
-		"migrationType": 1,
+		"migrationType": "SingleMigration",
 	}
 
 	resp := schema.Exec(ctx, query, opName, variables)
@@ -75,7 +75,7 @@ func TestSourceMigrationsTypeSourceDirFilter(t *testing.T) {
 	schema := graphql.MustParseSchema(schemaString, &RootResolver{loader: &mockedLoader{}}, opts...)
 
 	opName := "SourceMigrations"
-	query := `query SourceMigrations($sourceDir: String, $migrationType: MigrationTypeOptional) {
+	query := `query SourceMigrations($sourceDir: String, $migrationType: MigrationType) {
 	    sourceMigrations(sourceDir: $sourceDir, migrationType: $migrationType) {
 	      name,
 	      migrationType,
@@ -86,7 +86,7 @@ func TestSourceMigrationsTypeSourceDirFilter(t *testing.T) {
 	    }
   }`
 	variables := map[string]interface{}{
-		"migrationType": 1,
+		"migrationType": "SingleMigration",
 		"sourceDir":     "source",
 	}
 
@@ -105,7 +105,7 @@ func TestSourceMigrationsTypeSourceDirNameFilter(t *testing.T) {
 	schema := graphql.MustParseSchema(schemaString, &RootResolver{loader: &mockedLoader{}}, opts...)
 
 	opName := "SourceMigrations"
-	query := `query SourceMigrations($name: String, $migrationType: MigrationTypeOptional) {
+	query := `query SourceMigrations($name: String, $migrationType: MigrationType) {
 	    sourceMigrations(name: $name, migrationType: $migrationType) {
 	      name,
 	      migrationType,
@@ -116,7 +116,7 @@ func TestSourceMigrationsTypeSourceDirNameFilter(t *testing.T) {
 	    }
   }`
 	variables := map[string]interface{}{
-		"migrationType": 1,
+		"migrationType": "SingleMigration",
 		"name":          "201602220001.sql",
 	}
 
@@ -193,7 +193,7 @@ func TestSourceMigrations2Queries(t *testing.T) {
 	schema := graphql.MustParseSchema(schemaString, &RootResolver{loader: &mockedLoader{}}, opts...)
 
 	opName := "SourceMigrations"
-	query := `query SourceMigrations($singleMigrationType: MigrationTypeOptional, $tenantMigrationType: MigrationTypeOptional) {
+	query := `query SourceMigrations($singleMigrationType: MigrationType, $tenantMigrationType: MigrationType) {
 	    singleTenantMigrations: sourceMigrations(migrationType: $singleMigrationType) {
 	      name,
 	      migrationType,
@@ -212,8 +212,8 @@ func TestSourceMigrations2Queries(t *testing.T) {
 	    }
   }`
 	variables := map[string]interface{}{
-		"singleMigrationType": 1,
-		"tenantMigrationType": 2,
+		"singleMigrationType": "SingleMigration",
+		"tenantMigrationType": "TenantMigration",
 	}
 
 	resp := schema.Exec(ctx, query, opName, variables)

--- a/data/graphql_test.go
+++ b/data/graphql_test.go
@@ -1,0 +1,228 @@
+package data
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	graphql "github.com/graph-gophers/graphql-go"
+)
+
+func TestSourceMigrationsNoFilters(t *testing.T) {
+
+	ctx := context.Background()
+
+	opts := []graphql.SchemaOpt{graphql.UseFieldResolvers()}
+	schema := graphql.MustParseSchema(schemaString, &RootResolver{loader: &mockedLoader{}}, opts...)
+
+	opName := "SourceMigrations"
+	query := `query SourceMigrations {
+      sourceMigrations {
+        name,
+        migrationType,
+        sourceDir,
+      	file,
+      	contents,
+        checkSum
+      }
+    }`
+	variables := map[string]interface{}{}
+
+	resp := schema.Exec(ctx, query, opName, variables)
+	jsonMap := make(map[string]interface{})
+	err := json.Unmarshal(resp.Data, &jsonMap)
+	assert.Nil(t, err)
+	results := len(jsonMap["sourceMigrations"].([]interface{}))
+	assert.Equal(t, 5, results)
+}
+
+func TestSourceMigrationsTypeFilter(t *testing.T) {
+
+	ctx := context.Background()
+
+	opts := []graphql.SchemaOpt{graphql.UseFieldResolvers()}
+	schema := graphql.MustParseSchema(schemaString, &RootResolver{loader: &mockedLoader{}}, opts...)
+
+	opName := "SourceMigrations"
+	query := `query SourceMigrations($migrationType: MigrationTypeOptional) {
+	    sourceMigrations(migrationType: $migrationType) {
+	      name,
+	      migrationType,
+	      sourceDir,
+	    	file,
+	    	contents,
+	      checkSum
+	    }
+  }`
+	variables := map[string]interface{}{
+		"migrationType": 1,
+	}
+
+	resp := schema.Exec(ctx, query, opName, variables)
+	jsonMap := make(map[string]interface{})
+	err := json.Unmarshal(resp.Data, &jsonMap)
+	assert.Nil(t, err)
+	results := len(jsonMap["sourceMigrations"].([]interface{}))
+	assert.Equal(t, 4, results)
+}
+
+func TestSourceMigrationsTypeSourceDirFilter(t *testing.T) {
+	ctx := context.Background()
+
+	opts := []graphql.SchemaOpt{graphql.UseFieldResolvers()}
+	schema := graphql.MustParseSchema(schemaString, &RootResolver{loader: &mockedLoader{}}, opts...)
+
+	opName := "SourceMigrations"
+	query := `query SourceMigrations($sourceDir: String, $migrationType: MigrationTypeOptional) {
+	    sourceMigrations(sourceDir: $sourceDir, migrationType: $migrationType) {
+	      name,
+	      migrationType,
+	      sourceDir,
+	    	file,
+	    	contents,
+	      checkSum
+	    }
+  }`
+	variables := map[string]interface{}{
+		"migrationType": 1,
+		"sourceDir":     "source",
+	}
+
+	resp := schema.Exec(ctx, query, opName, variables)
+	jsonMap := make(map[string]interface{})
+	err := json.Unmarshal(resp.Data, &jsonMap)
+	assert.Nil(t, err)
+	results := len(jsonMap["sourceMigrations"].([]interface{}))
+	assert.Equal(t, 3, results)
+}
+
+func TestSourceMigrationsTypeSourceDirNameFilter(t *testing.T) {
+	ctx := context.Background()
+
+	opts := []graphql.SchemaOpt{graphql.UseFieldResolvers()}
+	schema := graphql.MustParseSchema(schemaString, &RootResolver{loader: &mockedLoader{}}, opts...)
+
+	opName := "SourceMigrations"
+	query := `query SourceMigrations($name: String, $migrationType: MigrationTypeOptional) {
+	    sourceMigrations(name: $name, migrationType: $migrationType) {
+	      name,
+	      migrationType,
+	      sourceDir,
+	    	file,
+	    	contents,
+	      checkSum
+	    }
+  }`
+	variables := map[string]interface{}{
+		"migrationType": 1,
+		"name":          "201602220001.sql",
+	}
+
+	resp := schema.Exec(ctx, query, opName, variables)
+	jsonMap := make(map[string]interface{})
+	err := json.Unmarshal(resp.Data, &jsonMap)
+	assert.Nil(t, err)
+	results := len(jsonMap["sourceMigrations"].([]interface{}))
+	assert.Equal(t, 2, results)
+}
+
+func TestSourceMigrationsTypeNameFilter(t *testing.T) {
+	ctx := context.Background()
+
+	opts := []graphql.SchemaOpt{graphql.UseFieldResolvers()}
+	schema := graphql.MustParseSchema(schemaString, &RootResolver{loader: &mockedLoader{}}, opts...)
+
+	opName := "SourceMigrations"
+	query := `query SourceMigrations($file: String) {
+	    sourceMigrations(file: $file) {
+	      name,
+	      migrationType,
+	      sourceDir,
+	    	file,
+	    	contents,
+	      checkSum
+	    }
+  }`
+	variables := map[string]interface{}{
+		"file": "config/201602220001.sql",
+	}
+
+	resp := schema.Exec(ctx, query, opName, variables)
+	jsonMap := make(map[string]interface{})
+	err := json.Unmarshal(resp.Data, &jsonMap)
+	assert.Nil(t, err)
+	results := len(jsonMap["sourceMigrations"].([]interface{}))
+	assert.Equal(t, 1, results)
+}
+
+func TestSourceMigration(t *testing.T) {
+	ctx := context.Background()
+
+	opts := []graphql.SchemaOpt{graphql.UseFieldResolvers()}
+	schema := graphql.MustParseSchema(schemaString, &RootResolver{loader: &mockedLoader{}}, opts...)
+
+	opName := "SourceMigration"
+	query := `query SourceMigration($file: String!) {
+	    sourceMigration(file: $file) {
+	      name,
+	      migrationType,
+	      sourceDir,
+	    	file
+	    }
+  }`
+	variables := map[string]interface{}{
+		"file": "config/201602220001.sql",
+	}
+
+	resp := schema.Exec(ctx, query, opName, variables)
+	jsonMap := make(map[string]interface{})
+	err := json.Unmarshal(resp.Data, &jsonMap)
+	assert.Nil(t, err)
+	results := jsonMap["sourceMigration"].(map[string]interface{})
+	assert.Equal(t, "config", results["sourceDir"])
+	assert.Equal(t, "201602220001.sql", results["name"])
+	assert.Equal(t, "config/201602220001.sql", results["file"])
+}
+
+func TestSourceMigrations2Queries(t *testing.T) {
+	ctx := context.Background()
+
+	opts := []graphql.SchemaOpt{graphql.UseFieldResolvers()}
+	schema := graphql.MustParseSchema(schemaString, &RootResolver{loader: &mockedLoader{}}, opts...)
+
+	opName := "SourceMigrations"
+	query := `query SourceMigrations($singleMigrationType: MigrationTypeOptional, $tenantMigrationType: MigrationTypeOptional) {
+	    singleTenantMigrations: sourceMigrations(migrationType: $singleMigrationType) {
+	      name,
+	      migrationType,
+	      sourceDir,
+	    	file,
+	    	contents,
+	      checkSum
+	    }
+      multiTenantMigrations: sourceMigrations(migrationType: $tenantMigrationType) {
+	      name,
+	      migrationType,
+	      sourceDir,
+	    	file,
+	    	contents,
+	      checkSum
+	    }
+  }`
+	variables := map[string]interface{}{
+		"singleMigrationType": 1,
+		"tenantMigrationType": 2,
+	}
+
+	resp := schema.Exec(ctx, query, opName, variables)
+
+	jsonMap := make(map[string]interface{})
+	err := json.Unmarshal(resp.Data, &jsonMap)
+	assert.Nil(t, err)
+	single := len(jsonMap["singleTenantMigrations"].([]interface{}))
+	assert.Equal(t, 4, single)
+	multi := len(jsonMap["multiTenantMigrations"].([]interface{}))
+	assert.Equal(t, 1, multi)
+}

--- a/db/db.go
+++ b/db/db.go
@@ -128,7 +128,7 @@ func (bc *baseConnector) GetTenants() []types.Tenant {
 		if err = rows.Scan(&name); err != nil {
 			panic(fmt.Sprintf("Could not read tenants: %v", err))
 		}
-		tenants = append(tenants, types.Tenant{name})
+		tenants = append(tenants, types.Tenant{Name: name})
 	}
 
 	return tenants

--- a/db/db.go
+++ b/db/db.go
@@ -15,7 +15,7 @@ import (
 
 // Connector interface abstracts all DB operations performed by migrator
 type Connector interface {
-	GetTenants() []string
+	GetTenants() []types.Tenant
 	GetAppliedMigrations() []types.MigrationDB
 	ApplyMigrations(types.MigrationsModeType, []types.Migration) *types.MigrationResults
 	AddTenantAndApplyMigrations(types.MigrationsModeType, string, []types.Migration) *types.MigrationResults
@@ -113,10 +113,10 @@ func (bc *baseConnector) getTenantSelectSQL() string {
 }
 
 // GetTenants returns a list of all DB tenants
-func (bc *baseConnector) GetTenants() []string {
+func (bc *baseConnector) GetTenants() []types.Tenant {
 	tenantSelectSQL := bc.getTenantSelectSQL()
 
-	tenants := []string{}
+	tenants := []types.Tenant{}
 
 	rows, err := bc.db.Query(tenantSelectSQL)
 	if err != nil {
@@ -128,7 +128,7 @@ func (bc *baseConnector) GetTenants() []string {
 		if err = rows.Scan(&name); err != nil {
 			panic(fmt.Sprintf("Could not read tenants: %v", err))
 		}
-		tenants = append(tenants, name)
+		tenants = append(tenants, types.Tenant{name})
 	}
 
 	return tenants
@@ -246,7 +246,8 @@ func (bc *baseConnector) AddTenantAndApplyMigrations(mode types.MigrationsModeTy
 		panic(fmt.Sprintf("Failed to add tenant entry: %v", err))
 	}
 
-	results := bc.applyMigrationsInTx(tx, mode, []string{tenant}, migrations)
+	tenantStruct := types.Tenant{Name: tenant}
+	results := bc.applyMigrationsInTx(tx, mode, []types.Tenant{tenantStruct}, migrations)
 
 	return results
 }
@@ -277,7 +278,7 @@ func (bc *baseConnector) getSchemaPlaceHolder() string {
 	return schemaPlaceHolder
 }
 
-func (bc *baseConnector) applyMigrationsInTx(tx *sql.Tx, mode types.MigrationsModeType, tenants []string, migrations []types.Migration) *types.MigrationResults {
+func (bc *baseConnector) applyMigrationsInTx(tx *sql.Tx, mode types.MigrationsModeType, tenants []types.Tenant, migrations []types.Migration) *types.MigrationResults {
 
 	results := &types.MigrationResults{
 		StartedAt: time.Now(),
@@ -301,7 +302,9 @@ func (bc *baseConnector) applyMigrationsInTx(tx *sql.Tx, mode types.MigrationsMo
 	for _, m := range migrations {
 		var schemas []string
 		if m.MigrationType == types.MigrationTypeTenantMigration || m.MigrationType == types.MigrationTypeTenantScript {
-			schemas = tenants
+			for _, t := range tenants {
+				schemas = append(schemas, t.Name)
+			}
 		} else {
 			schemas = []string{filepath.Base(m.SourceDir)}
 		}

--- a/db/db.go
+++ b/db/db.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/graph-gophers/graphql-go"
+
 	"github.com/lukaszbudnik/migrator/common"
 	"github.com/lukaszbudnik/migrator/config"
 	"github.com/lukaszbudnik/migrator/types"
@@ -160,7 +162,7 @@ func (bc *baseConnector) GetAppliedMigrations() []types.MigrationDB {
 			panic(fmt.Sprintf("Could not read DB migration: %v", err.Error()))
 		}
 		mdef := types.Migration{Name: name, SourceDir: sourceDir, File: filename, MigrationType: migrationType, Contents: contents, CheckSum: checksum}
-		dbMigrations = append(dbMigrations, types.MigrationDB{Migration: mdef, Schema: schema, AppliedAt: appliedAt})
+		dbMigrations = append(dbMigrations, types.MigrationDB{Migration: mdef, Schema: schema, AppliedAt: graphql.Time{Time: appliedAt}})
 	}
 	return dbMigrations
 }

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -62,9 +62,9 @@ func TestGetTenants(t *testing.T) {
 	tenants := connector.GetTenants()
 
 	assert.True(t, len(tenants) >= 3)
-	assert.Contains(t, tenants, "abc")
-	assert.Contains(t, tenants, "def")
-	assert.Contains(t, tenants, "xyz")
+	assert.Contains(t, tenants, types.Tenant{Name: "abc"})
+	assert.Contains(t, tenants, types.Tenant{Name: "def"})
+	assert.Contains(t, tenants, types.Tenant{Name: "xyz"})
 }
 
 func TestApplyMigrations(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/gin-gonic/gin v1.5.0
 	github.com/go-playground/universal-translator v0.17.0 // indirect
 	github.com/go-sql-driver/mysql v1.5.0
+	github.com/graph-gophers/graphql-go v0.0.0-20200207002730-8334863f2c8b
 	github.com/leodido/go-urn v1.2.0 // indirect
 	github.com/lib/pq v1.3.0
 	github.com/pkg/errors v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,8 @@ github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LB
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe/go.mod h1:8vg3r2VgvsThLBIFL93Qb5yWzgyZWhEmBwUJWevAkK0=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/graph-gophers/graphql-go v0.0.0-20200207002730-8334863f2c8b h1:fRjb9ncV+Aad/w56TstaCM/xGusFsfDfeGhhc+k4IBg=
+github.com/graph-gophers/graphql-go v0.0.0-20200207002730-8334863f2c8b/go.mod h1:9CQHMSxwO4MprSdzoIEobiHpoLtHm77vfxsvsIN5Vuc=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
@@ -38,6 +40,8 @@ github.com/mattn/go-ieproxy v0.0.0-20190610004146-91bb50d98149/go.mod h1:31jz6HN
 github.com/mattn/go-isatty v0.0.9/go.mod h1:YNRxwqDuOph6SZLI9vUUz6OYw3QyUt7WiY2yME+cCiQ=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/opentracing/opentracing-go v1.1.0 h1:pWlfV3Bxv7k65HYwkikxat0+s3pV4bsqf19k25Ur8rU=
+github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/loader/s3_loader.go
+++ b/loader/s3_loader.go
@@ -66,15 +66,14 @@ func (s3l *s3Loader) getObjectList(client s3iface.S3API, prefixes []string) []*s
 			MaxKeys: aws.Int64(1000),
 		}
 
-		pageNum := 0
 		err := client.ListObjectsV2Pages(input,
 			func(page *s3.ListObjectsV2Output, lastPage bool) bool {
-				pageNum++
+
 				for _, o := range page.Contents {
 					objects = append(objects, o.Key)
 				}
 
-				return pageNum <= 10
+				return !lastPage
 			})
 
 		if err != nil {

--- a/loader/s3_loader_test.go
+++ b/loader/s3_loader_test.go
@@ -62,7 +62,7 @@ func TestS3GetSourceMigrations(t *testing.T) {
 	mock := &mockS3Client{}
 
 	config := &config.Config{
-		BaseLocation:     "s3://lukasz-budnik-migrator-us-east-1",
+		BaseLocation:     "s3://your-bucket-migrator",
 		SingleMigrations: []string{"migrations/config", "migrations/ref"},
 		TenantMigrations: []string{"migrations/tenants"},
 		SingleScripts:    []string{"migrations/config-scripts"},

--- a/server/server_mocks.go
+++ b/server/server_mocks.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/graph-gophers/graphql-go"
+
 	"github.com/lukaszbudnik/migrator/config"
 	"github.com/lukaszbudnik/migrator/coordinator"
 	"github.com/lukaszbudnik/migrator/types"
@@ -41,7 +43,7 @@ func (m *mockedCoordinator) GetSourceMigrations() []types.Migration {
 func (m *mockedCoordinator) GetAppliedMigrations() []types.MigrationDB {
 	m1 := types.Migration{Name: "201602220000.sql", SourceDir: "source", File: "source/201602220000.sql", MigrationType: types.MigrationTypeSingleMigration, Contents: "select abc", CheckSum: "sha256"}
 	d1 := time.Date(2016, 02, 22, 16, 41, 1, 123, time.UTC)
-	ms := []types.MigrationDB{{Migration: m1, Schema: "source", AppliedAt: d1}}
+	ms := []types.MigrationDB{{Migration: m1, Schema: "source", AppliedAt: graphql.Time{Time: d1}}}
 	return ms
 }
 

--- a/server/server_mocks.go
+++ b/server/server_mocks.go
@@ -45,8 +45,11 @@ func (m *mockedCoordinator) GetAppliedMigrations() []types.MigrationDB {
 	return ms
 }
 
-func (m *mockedCoordinator) GetTenants() []string {
-	return []string{"a", "b", "c"}
+func (m *mockedCoordinator) GetTenants() []types.Tenant {
+	a := types.Tenant{Name: "a"}
+	b := types.Tenant{Name: "b"}
+	c := types.Tenant{Name: "c"}
+	return []types.Tenant{a, b, c}
 }
 
 func (m *mockedCoordinator) VerifySourceMigrationsCheckSums() (bool, []types.Migration) {

--- a/types/types.go
+++ b/types/types.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	"encoding/json"
+	"fmt"
 	"time"
 
 	"gopkg.in/go-playground/validator.v9"
@@ -19,6 +21,77 @@ const (
 	// MigrationTypeTenantScript is used to mark tenant SQL scripts which is executed always
 	MigrationTypeTenantScript MigrationType = 4
 )
+
+// ImplementsGraphQLType maps this custom Go type
+// to the graphql scalar type in the schema.
+func (MigrationType) ImplementsGraphQLType(name string) bool {
+	return name == "MigrationType"
+}
+
+// This function will be called whenever you use the
+// time scalar as an input
+func (t *MigrationType) UnmarshalGraphQL(input interface{}) error {
+	switch input := input.(type) {
+	case MigrationType:
+		t = &input
+		return nil
+	case uint32:
+		mt := MigrationType(input)
+		t = &mt
+		return nil
+	case int:
+		fmt.Printf("I'm int %v\n", input)
+		mt := MigrationType(input)
+		fmt.Printf("I'm MT %v\n", mt)
+		fmt.Printf("I'm MT %v\n", &mt)
+		t = &mt
+		return nil
+	default:
+		return fmt.Errorf("wrong type %v", input)
+	}
+}
+
+// This function will be called whenever you
+// query for fields that use the Time type
+func (t MigrationType) MarshalJSON() ([]byte, error) {
+	return json.Marshal(uint32(t))
+}
+
+type MigrationTypeOptional struct {
+	MigrationType MigrationType
+}
+
+// ImplementsGraphQLType maps this custom Go type
+// to the graphql scalar type in the schema.
+func (MigrationTypeOptional) ImplementsGraphQLType(name string) bool {
+	return name == "MigrationTypeOptional"
+}
+
+// This function will be called whenever you use the
+// time scalar as an input
+func (t *MigrationTypeOptional) UnmarshalGraphQL(input interface{}) error {
+	switch input := input.(type) {
+	case MigrationType:
+		t.MigrationType = input
+		return nil
+	case uint32:
+		mt := MigrationType(input)
+		t.MigrationType = mt
+		return nil
+	case int:
+		mt := MigrationType(input)
+		t.MigrationType = mt
+		return nil
+	default:
+		return fmt.Errorf("Could not unmarshal graphql MigrationTypeOptional: %v", input)
+	}
+}
+
+// This function will be called whenever you
+// query for fields that use the Time type
+func (t MigrationTypeOptional) MarshalJSON() ([]byte, error) {
+	return json.Marshal(uint32(t.MigrationType))
+}
 
 // MigrationsResponseType represents type of response either full or summary
 type MigrationsResponseType string

--- a/types/types.go
+++ b/types/types.go
@@ -1,7 +1,6 @@
 package types
 
 import (
-	"encoding/json"
 	"fmt"
 	"time"
 
@@ -22,75 +21,46 @@ const (
 	MigrationTypeTenantScript MigrationType = 4
 )
 
-// ImplementsGraphQLType maps this custom Go type
-// to the graphql scalar type in the schema.
+// ImplementsGraphQLType maps MigrationType Go type
+// to the graphql scalar type in the schema
 func (MigrationType) ImplementsGraphQLType(name string) bool {
 	return name == "MigrationType"
 }
 
-// This function will be called whenever you use the
-// time scalar as an input
+// String converts MigrationType Go type to string literal
+func (t MigrationType) String() string {
+	switch t {
+	case MigrationTypeSingleMigration:
+		return "SingleMigration"
+	case MigrationTypeTenantMigration:
+		return "TenantMigration"
+	case MigrationTypeSingleScript:
+		return "SingleScript"
+	case MigrationTypeTenantScript:
+		return "TenantScript"
+	default:
+		panic(fmt.Sprintf("Unknown migration type value: %v", uint32(t)))
+	}
+}
+
+// UnmarshalGraphQL converts string literal to MigrationType Go type
 func (t *MigrationType) UnmarshalGraphQL(input interface{}) error {
-	switch input := input.(type) {
-	case MigrationType:
-		t = &input
+	if str, ok := input.(string); ok {
+		switch str {
+		case "SingleMigration":
+			*t = MigrationTypeSingleMigration
+		case "TenantMigration":
+			*t = MigrationTypeTenantMigration
+		case "SingleScript":
+			*t = MigrationTypeSingleScript
+		case "TenantScript":
+			*t = MigrationTypeTenantScript
+		default:
+			panic(fmt.Sprintf("Unknown migration type literal: %v", str))
+		}
 		return nil
-	case uint32:
-		mt := MigrationType(input)
-		t = &mt
-		return nil
-	case int:
-		fmt.Printf("I'm int %v\n", input)
-		mt := MigrationType(input)
-		fmt.Printf("I'm MT %v\n", mt)
-		fmt.Printf("I'm MT %v\n", &mt)
-		t = &mt
-		return nil
-	default:
-		return fmt.Errorf("wrong type %v", input)
 	}
-}
-
-// This function will be called whenever you
-// query for fields that use the Time type
-func (t MigrationType) MarshalJSON() ([]byte, error) {
-	return json.Marshal(uint32(t))
-}
-
-type MigrationTypeOptional struct {
-	MigrationType MigrationType
-}
-
-// ImplementsGraphQLType maps this custom Go type
-// to the graphql scalar type in the schema.
-func (MigrationTypeOptional) ImplementsGraphQLType(name string) bool {
-	return name == "MigrationTypeOptional"
-}
-
-// This function will be called whenever you use the
-// time scalar as an input
-func (t *MigrationTypeOptional) UnmarshalGraphQL(input interface{}) error {
-	switch input := input.(type) {
-	case MigrationType:
-		t.MigrationType = input
-		return nil
-	case uint32:
-		mt := MigrationType(input)
-		t.MigrationType = mt
-		return nil
-	case int:
-		mt := MigrationType(input)
-		t.MigrationType = mt
-		return nil
-	default:
-		return fmt.Errorf("Could not unmarshal graphql MigrationTypeOptional: %v", input)
-	}
-}
-
-// This function will be called whenever you
-// query for fields that use the Time type
-func (t MigrationTypeOptional) MarshalJSON() ([]byte, error) {
-	return json.Marshal(uint32(t.MigrationType))
+	return fmt.Errorf("Wrong type for MigrationType: %T", input)
 }
 
 // MigrationsResponseType represents type of response either full or summary

--- a/types/types.go
+++ b/types/types.go
@@ -105,6 +105,11 @@ func ValidateMigrationsResponseType(fl validator.FieldLevel) bool {
 	return false
 }
 
+// Tenant contains basic information about tenant
+type Tenant struct {
+	Name string `json:"name"`
+}
+
 // Migration contains basic information about migration
 type Migration struct {
 	Name          string        `json:"name"`

--- a/types/types.go
+++ b/types/types.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/graph-gophers/graphql-go"
 	"gopkg.in/go-playground/validator.v9"
 )
 
@@ -123,8 +124,8 @@ type Migration struct {
 // MigrationDB embeds Migration and adds DB-specific fields
 type MigrationDB struct {
 	Migration
-	Schema    string    `json:"schema"`
-	AppliedAt time.Time `json:"appliedAt"`
+	Schema    string       `json:"schema"`
+	AppliedAt graphql.Time `json:"appliedAt"`
 }
 
 // MigrationResults contains summary information about executed migrations


### PR DESCRIPTION
This pull contains first implementation of /v2 GraphQL-based API.

The following queries are supported:

* sourceMigrations()
* sourceMigration()
* dbMigrations()
* dbMigration()
* tenants()

For more please see GraphQL schema in data package.