### PR TITLE
Graphql create version create tenant

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ EOF
 curl -d @create_tenant.txt http://localhost:8080/v2/service
 ```
 
-Query data (yes, migrator supports multiple operations in a single GrapQL query):
+Query data (yes, migrator supports multiple operations in a single GraphQL query):
 
 ```
 # new lines are used for readability but have to be removed from the actual request

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # migrator [![Build Status](https://travis-ci.org/lukaszbudnik/migrator.svg?branch=master)](https://travis-ci.org/lukaszbudnik/migrator) [![Go Report Card](https://goreportcard.com/badge/github.com/lukaszbudnik/migrator)](https://goreportcard.com/report/github.com/lukaszbudnik/migrator) [![codecov](https://codecov.io/gh/lukaszbudnik/migrator/branch/master/graph/badge.svg)](https://codecov.io/gh/lukaszbudnik/migrator)
 
-Super fast and lightweight DB migration tool written in go.
+Super fast and lightweight DB migration tool written in go. migrator consumes 6MB of memory and outperforms other DB migration/evolution frameworks by a few orders of magnitude.
 
-migrator manages and versions all the DB changes for you and completely eliminates manual and error-prone administrative tasks. migrator not only supports single schemas, but also comes with a multi-tenant support.
+migrator manages and versions all the DB changes for you and completely eliminates manual and error-prone administrative tasks. migrator versions can be used for auditing and compliance purposes. migrator not only supports single schemas, but also comes with a multi-schema support (ideal for multi-schema multi-tenant SaaS products).
 
 migrator runs as a HTTP REST service and can be easily integrated into your continuous integration and continuous delivery pipeline.
 
-Further, there is an official docker image available on docker hub. [lukasz/migrator](https://hub.docker.com/r/lukasz/migrator) is ultra lightweight and has a size of 15MB. Ideal for micro-services deployments!
+The official docker image is available on docker hub at [lukasz/migrator](https://hub.docker.com/r/lukasz/migrator). It is ultra lightweight and has a size of 15MB. Ideal for micro-services deployments!
 
 # Table of contents
 
@@ -14,6 +14,7 @@ Further, there is an official docker image available on docker hub. [lukasz/migr
   * [GET /](#get-)
   * [/v2 - GraphQL API](#v2---graphql-api)
     * [GET /v2/config](#get-v2config)
+    * [GET /v2/schema](#get-v2schema)
     * [POST /v2/service](#post-v2service)
   * [/v1](#v1)
     * [GET /v1/config](#get-v1config)
@@ -133,6 +134,7 @@ Sample HTTP response (truncated):
 <
 schema {
   query: Query
+  mutation: Mutation
 }
 enum MigrationType {
   SingleMigration
@@ -150,26 +152,258 @@ This is a GraphQL endpoint which handles both query and mutation requests.
 The current GraphQL schema together with description in comments is as follows:
 
 ```graphql
-
+schema {
+  query: Query
+  mutation: Mutation
+}
+enum MigrationType {
+  SingleMigration
+  TenantMigration
+  SingleScript
+  TenantScript
+}
+enum Action {
+  // Apply is the default action, migrator reads all source migrations and applies them
+  Apply
+  // Sync is an action where migrator reads all source migrations and marks them as applied in DB
+  // typical use cases are:
+  // importing source migrations from a legacy tool or synchronising tenant migrations when tenant was created using external tool
+  Sync
+}
+scalar Time
+interface Migration {
+  name: String!
+  migrationType: MigrationType!
+  sourceDir: String!
+  file: String!
+  contents: String!
+  checkSum: String!
+}
+type SourceMigration implements Migration {
+  name: String!
+  migrationType: MigrationType!
+  sourceDir: String!
+  file: String!
+  contents: String!
+  checkSum: String!
+}
+type DBMigration implements Migration {
+  id: Int!
+  name: String!
+  migrationType: MigrationType!
+  sourceDir: String!
+  file: String!
+  contents: String!
+  checkSum: String!
+  schema: String!
+  created: Time!
+}
+type Tenant {
+  name: String!
+}
+type Version {
+  id: Int!
+  name: String!
+  created: Time!
+  dbMigrations: [DBMigration!]!
+}
+input SourceMigrationFilters {
+  name: String
+  sourceDir: String
+  file: String
+  migrationType: MigrationType
+}
+input VersionInput {
+  versionName: String!
+  action: Action = Apply
+  dryRun: Boolean = false
+}
+input TenantInput {
+  tenantName: String!
+  versionName: String!
+  action: Action = Apply
+  dryRun: Boolean = false
+}
+type Summary {
+  // date time operation started
+  startedAt: Time!
+  // how long the operation took in nanoseconds
+	duration: Int!
+  // number of tenants in the system
+	tenants: Int!
+  // number of applied single schema migrations
+	singleMigrations: Int!
+  // number of applied multi-tenant schema migrations
+	tenantMigrations: Int!
+  // number of all applied multi-tenant schema migrations (equals to tenants * tenantMigrations)
+	tenantMigrationsTotal: Int!
+  // sum of singleMigrations and tenantMigrationsTotal
+	migrationsGrandTotal: Int!
+  // number of applied single schema scripts
+	singleScripts: Int!
+  // number of applied multi-tenant schema scripts
+	tenantScripts: Int!
+  // number of all applied multi-tenant schema migrations (equals to tenants * tenantScripts)
+	tenantScriptsTotal: Int!
+  // sum of singleScripts and tenantScriptsTotal
+	scriptsGrandTotal: Int!
+}
+type CreateResults {
+  summary: Summary!
+  version: Version!
+}
+type Query {
+  // returns array of SourceMigration objects
+  // note that if input query includes contents field this operation can produce large amounts of data - see sourceMigration(file: String!)
+  // all parameters are optional and can be used to filter source migrations
+  sourceMigrations(filters: SourceMigrationFilters): [SourceMigration!]!
+  // returns a single SourceMigration
+  // this operation can be used to fetch a complete SourceMigration including its contents field
+  // file is the unique identifier for a source migration which you can get from sourceMigrations() operation
+  sourceMigration(file: String!): SourceMigration
+  // returns array of Version objects
+  // note that if input query includes DBMigration array this operation can produce large amounts of data - see version(id: Int!) or dbMigration(id: Int!)
+  // file is optional and can be used to return versions in which given source migration was applied
+  versions(file: String): [Version!]!
+  // returns a single Version
+  // note that if input query includes contents field this operation can produce large amounts of data - see dbMigration(id: Int!)
+  // id is the unique identifier of a version which you can get from versions() operation
+  version(id: Int!): Version
+  // returns a single DBMigration
+  // this operation can be used to fetch a complete SourceMigration including its contents field
+  // id is the unique identifier of a version which you can get from versions(file: String) or version(id: Int!) operations
+  dbMigration(id: Int!): DBMigration
+  // returns array of Tenant objects
+  tenants(): [Tenant!]!
+}
+type Mutation {
+  createVersion(input: VersionInput!): CreateResults!
+  createTenant(input: TenantInput!): CreateResults!
+}
 ```
 
 There are code generators available which can generate client code based on GraphQL schema. This would be the preferred way of consuming migrator's GraphQL endpoint.
 
-Below are a couple of curl examples to get you started.
+However, below are a few curl examples to get you started.
 
 Create new version:
 
 ```
+# versionName parameter is required and can be:
+# 1. your version number
+# 2. if you do multiple deploys to dev envs perhaps it could be a version number concatenated with current date time
+# 3. or if you do CI/CD the commit sha (recommended)
+COMMIT_SHA="acfd70fd1f4c7413e558c03ed850012627c9caa9"
+# new lines are used for readability but have to be removed from the actual request
+cat <<EOF | tr -d "\n" > create_version.txt
+{
+  "query": "
+  mutation CreateVersion(\$input: VersionInput!) {
+    createVersion(input: \$input) {
+      version {
+        id,
+        name,
+      }
+      summary {
+        startedAt
+        tenants
+        migrationsGrandTotal
+        scriptsGrandTotal
+      }
+    }
+  }",
+  "operationName": "CreateVersion",
+  "variables": {
+    "input": {
+      "versionName": "$COMMIT_SHA"
+    }
+  }
+}
+EOF
+# and now execute the above query
+curl -d @create_version.txt http://localhost:8080/v2/service
 ```
 
-Create new tenant:
+Create new tenant, run in dry run and instead of default `Apply`, run `Sync` action, also include DB migrations in output:
 
 ```
+# versionName parameter is required and can be:
+# 1. your version number
+# 2. if you do multiple deploys to dev envs perhaps it could be a version number concatenated with current date time
+# 3. or if you do CI/CD the commit sha (recommended)
+COMMIT_SHA="acfd70fd1f4c7413e558c03ed850012627c9caa9"
+# tenantName parameter is also required (should not come as a surprise since we want to create new tenant)
+TENANT_NAME="new_customer_of_yours"
+# new lines are used for readability but have to be removed from the actual request
+cat <<EOF | tr -d "\n" > create_tenant.txt
+{
+  "query": "
+  mutation CreateTenant(\$input: TenantInput!) {
+    createTenant(input: \$input) {
+      version {
+        id,
+        name,
+        dbMigrations {
+          id,
+          file,
+          schema
+        }
+      }
+      summary {
+        startedAt
+        tenants
+        migrationsGrandTotal
+        scriptsGrandTotal
+      }
+    }
+  }",
+  "operationName": "CreateTenant",
+  "variables": {
+    "input": {
+      "versionName": "$COMMIT_SHA - $TENANT_NAME",
+      "tenantName": "$TENANT_NAME"
+    }
+  }
+}
+EOF
+# and now execute the above query
+curl -d @create_tenant.txt http://localhost:8080/v2/service
 ```
 
-Query data:
+Query data (yes, migrator supports multiple operations in a single GrapQL query):
 
 ```
+# new lines are used for readability but have to be removed from the actual request
+cat <<EOF | tr -d "\n" > query.txt
+{
+  "query": "
+  query Data(\$singleMigrationsFilters: SourceMigrationFilters, \$tenantMigrationsFilters: SourceMigrationFilters) {
+    singleTenantSourceMigrations: sourceMigrations(filters: \$singleMigrationsFilters) {
+      file
+      migrationType
+    }
+    multiTenantSourceMigrations: sourceMigrations(filters: \$tenantMigrationsFilters) {
+      file
+      migrationType
+      checkSum
+    }
+    tenants {
+      name
+    }
+  }",
+  "operationName": "Data",
+  "variables": {
+    "singleMigrationsFilters": {
+      "migrationType": "SingleMigration"
+    },
+    "tenantMigrationsFilters": {
+      "migrationType": "TenantMigration"
+    }
+  }
+}
+EOF
+# and now execute the above query
+curl -d @query.txt http://localhost:8080/v2/service
 ```
 
 For more GraphQL query and mutation examples see `data/graphql_test.go`.

--- a/config/config.go
+++ b/config/config.go
@@ -55,7 +55,7 @@ func FromBytes(contents []byte) (*Config, error) {
 	}
 
 	if len(config.BaseDir) > 0 && len(config.BaseLocation) == 0 {
-		common.Log("WARN", "Deprecated: config property `baseDir` will be removed in migrator v5.0, please rename it to `baseLocation`")
+		common.Log("WARN", "Deprecated: config property `baseDir` will be removed in migrator v2021.1.0, please rename it to `baseLocation`")
 		config.BaseLocation = config.BaseDir
 	}
 

--- a/coordinator/coordinator_mocks.go
+++ b/coordinator/coordinator_mocks.go
@@ -86,6 +86,14 @@ type mockedConnector struct {
 func (m *mockedConnector) Dispose() {
 }
 
+func (m *mockedConnector) CreateTenant(string, types.Action, bool, string, []types.Migration) (*types.MigrationResults, *types.Version) {
+	return &types.MigrationResults{}, &types.Version{}
+}
+
+func (m *mockedConnector) CreateVersion(string, types.Action, bool, []types.Migration) (*types.MigrationResults, *types.Version) {
+	return &types.MigrationResults{}, &types.Version{}
+}
+
 func (m *mockedConnector) AddTenantAndApplyMigrations(types.MigrationsModeType, string, []types.Migration) *types.MigrationResults {
 	return &types.MigrationResults{}
 }

--- a/coordinator/coordinator_test.go
+++ b/coordinator/coordinator_test.go
@@ -375,3 +375,21 @@ func TestGetSourceMigrationsFilterFile(t *testing.T) {
 	migrations := coordinator.GetSourceMigrations(&filters)
 	assert.True(t, len(migrations) == 1)
 }
+
+func TestCreateVersion(t *testing.T) {
+	coordinator := New(context.TODO(), nil, newMockedConnector, newMockedDiskLoader, newErrorMockedNotifier)
+	defer coordinator.Dispose()
+	results := coordinator.CreateVersion("commit-sha", types.ActionApply, false)
+	assert.NotNil(t, results)
+	assert.NotNil(t, results.Summary)
+	assert.NotNil(t, results.Version)
+}
+
+func TestCreateTenant(t *testing.T) {
+	coordinator := New(context.TODO(), nil, newMockedConnector, newMockedDiskLoader, newErrorMockedNotifier)
+	defer coordinator.Dispose()
+	results := coordinator.CreateTenant("commit-sha", types.ActionSync, true, "NewTenant")
+	assert.NotNil(t, results)
+	assert.NotNil(t, results.Summary)
+	assert.NotNil(t, results.Version)
+}

--- a/data/graphql_mocks.go
+++ b/data/graphql_mocks.go
@@ -19,6 +19,17 @@ func (m *mockedCoordinator) safeString(value *string) string {
 	return *value
 }
 
+func (m *mockedCoordinator) CreateTenant(string, types.Action, bool, string) *types.CreateResults {
+	version, _ := m.GetVersionByID(0)
+	return &types.CreateResults{Summary: &types.MigrationResults{}, Version: version}
+}
+
+func (m *mockedCoordinator) CreateVersion(string, types.Action, bool) *types.CreateResults {
+	// re-use mocked version from GetVersionByID...
+	version, _ := m.GetVersionByID(0)
+	return &types.CreateResults{Summary: &types.MigrationResults{}, Version: version}
+}
+
 func (m *mockedCoordinator) GetSourceMigrations(filters *coordinator.SourceMigrationFilters) []types.Migration {
 
 	if filters == nil {

--- a/db/db_error_handling_test.go
+++ b/db/db_error_handling_test.go
@@ -195,7 +195,7 @@ func TestGetAppliedMigrationsError(t *testing.T) {
 	}
 }
 
-func TestApplyTransactionBeginError(t *testing.T) {
+func TestCreateVersionTransactionBeginError(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	assert.Nil(t, err)
 
@@ -213,7 +213,7 @@ func TestApplyTransactionBeginError(t *testing.T) {
 	migrationsToApply := []types.Migration{tenant1}
 
 	assert.PanicsWithValue(t, "Could not start transaction: trouble maker tx.Begin()", func() {
-		connector.ApplyMigrations(types.ModeTypeApply, migrationsToApply)
+		connector.CreateVersion("commit-sha", types.ActionApply, false, migrationsToApply)
 	})
 
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -221,7 +221,7 @@ func TestApplyTransactionBeginError(t *testing.T) {
 	}
 }
 
-func TestApplyInsertVersionPreparedStatementError(t *testing.T) {
+func TestCreateVersionInsertVersionPreparedStatementError(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	assert.Nil(t, err)
 
@@ -241,7 +241,7 @@ func TestApplyInsertVersionPreparedStatementError(t *testing.T) {
 	migrationsToApply := []types.Migration{tenant1}
 
 	assert.PanicsWithValue(t, "Could not create prepared statement for version: trouble maker", func() {
-		connector.ApplyMigrations(types.ModeTypeApply, migrationsToApply)
+		connector.CreateVersion("commit-sha", types.ActionApply, false, migrationsToApply)
 	})
 
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -249,7 +249,7 @@ func TestApplyInsertVersionPreparedStatementError(t *testing.T) {
 	}
 }
 
-func TestApplyInsertMigrationPreparedStatementError(t *testing.T) {
+func TestCreateVersionInsertMigrationPreparedStatementError(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	assert.Nil(t, err)
 
@@ -263,7 +263,7 @@ func TestApplyInsertMigrationPreparedStatementError(t *testing.T) {
 	mock.ExpectBegin()
 	// version
 	mock.ExpectPrepare("insert into migrator.migrator_versions")
-	mock.ExpectPrepare("insert into migrator.migrator_versions").ExpectQuery().WithArgs("")
+	mock.ExpectPrepare("insert into migrator.migrator_versions").ExpectQuery().WithArgs("commit-sha")
 	// migration
 	mock.ExpectPrepare("insert into migrator.migrator_migrations").WillReturnError(errors.New("trouble maker"))
 	mock.ExpectRollback()
@@ -273,7 +273,7 @@ func TestApplyInsertMigrationPreparedStatementError(t *testing.T) {
 	migrationsToApply := []types.Migration{tenant1}
 
 	assert.PanicsWithValue(t, "Could not create prepared statement for migration: trouble maker", func() {
-		connector.ApplyMigrations(types.ModeTypeApply, migrationsToApply)
+		connector.CreateVersion("commit-sha", types.ActionApply, false, migrationsToApply)
 	})
 
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -281,7 +281,7 @@ func TestApplyInsertMigrationPreparedStatementError(t *testing.T) {
 	}
 }
 
-func TestApplyMigrationSQLError(t *testing.T) {
+func TestCreateVersionMigrationSQLError(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	assert.Nil(t, err)
 
@@ -295,7 +295,7 @@ func TestApplyMigrationSQLError(t *testing.T) {
 	mock.ExpectBegin()
 	// version
 	mock.ExpectPrepare("insert into migrator.migrator_versions")
-	mock.ExpectPrepare("insert into migrator.migrator_versions").ExpectQuery().WithArgs("")
+	mock.ExpectPrepare("insert into migrator.migrator_versions").ExpectQuery().WithArgs("commit-sha")
 	// migration
 	mock.ExpectPrepare("insert into migrator.migrator_migrations")
 	mock.ExpectExec("insert into").WillReturnError(errors.New("trouble maker"))
@@ -306,7 +306,7 @@ func TestApplyMigrationSQLError(t *testing.T) {
 	migrationsToApply := []types.Migration{tenant1}
 
 	assert.PanicsWithValue(t, fmt.Sprintf("SQL migration %v failed with error: trouble maker", tenant1.File), func() {
-		connector.ApplyMigrations(types.ModeTypeApply, migrationsToApply)
+		connector.CreateVersion("commit-sha", types.ActionApply, false, migrationsToApply)
 	})
 
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -314,7 +314,7 @@ func TestApplyMigrationSQLError(t *testing.T) {
 	}
 }
 
-func TestApplyInsertMigrationError(t *testing.T) {
+func TestCreateVersionInsertMigrationError(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	assert.Nil(t, err)
 
@@ -333,7 +333,7 @@ func TestApplyInsertMigrationError(t *testing.T) {
 	mock.ExpectBegin()
 	// version
 	mock.ExpectPrepare("insert into migrator.migrator_versions")
-	mock.ExpectPrepare("insert into migrator.migrator_versions").ExpectQuery().WithArgs("")
+	mock.ExpectPrepare("insert into migrator.migrator_versions").ExpectQuery().WithArgs("commit-sha")
 	// migration
 	mock.ExpectPrepare("insert into migrator.migrator_migrations")
 	mock.ExpectExec("insert into").WillReturnResult(sqlmock.NewResult(0, 0))
@@ -341,7 +341,7 @@ func TestApplyInsertMigrationError(t *testing.T) {
 	mock.ExpectRollback()
 
 	assert.PanicsWithValue(t, "Failed to add migration entry: trouble maker", func() {
-		connector.ApplyMigrations(types.ModeTypeApply, migrationsToApply)
+		connector.CreateVersion("commit-sha", types.ActionApply, false, migrationsToApply)
 	})
 
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -349,7 +349,7 @@ func TestApplyInsertMigrationError(t *testing.T) {
 	}
 }
 
-func TestApplyMigrationsCommitError(t *testing.T) {
+func TestCreateVersionGetVersionError(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	assert.Nil(t, err)
 
@@ -358,8 +358,8 @@ func TestApplyMigrationsCommitError(t *testing.T) {
 	dialect := newDialect(config)
 	connector := baseConnector{newTestContext(), config, dialect, db}
 
-	time := time.Now().UnixNano()
-	m := types.Migration{Name: fmt.Sprintf("%v.sql", time), SourceDir: "tenants", File: fmt.Sprintf("tenants/%v.sql", time), MigrationType: types.MigrationTypeTenantMigration, Contents: "insert into {schema}.settings values (456, '456') "}
+	tn := time.Now().UnixNano()
+	m := types.Migration{Name: fmt.Sprintf("%v.sql", tn), SourceDir: "tenants", File: fmt.Sprintf("tenants/%v.sql", tn), MigrationType: types.MigrationTypeTenantMigration, Contents: "insert into {schema}.settings values (456, '456') "}
 	migrationsToApply := []types.Migration{m}
 
 	tenant := "tenantname"
@@ -368,15 +368,16 @@ func TestApplyMigrationsCommitError(t *testing.T) {
 	mock.ExpectBegin()
 	// version
 	mock.ExpectPrepare("insert into migrator.migrator_versions")
-	mock.ExpectPrepare("insert into migrator.migrator_versions").ExpectQuery().WithArgs("")
+	mock.ExpectPrepare("insert into migrator.migrator_versions").ExpectQuery().WithArgs("commit-sha")
 	// migration
 	mock.ExpectPrepare("insert into migrator.migrator_migrations")
 	mock.ExpectExec("insert into").WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectPrepare("insert into migrator.migrator_migrations").ExpectExec().WithArgs(m.Name, m.SourceDir, m.File, m.MigrationType, tenant, m.Contents, m.CheckSum, 0).WillReturnResult(sqlmock.NewResult(0, 0))
-	mock.ExpectCommit().WillReturnError(errors.New("tx trouble maker"))
+	// get version
+	mock.ExpectQuery("select").WillReturnError(errors.New("get version trouble maker"))
 
-	assert.PanicsWithValue(t, "Could not commit transaction: tx trouble maker", func() {
-		connector.ApplyMigrations(types.ModeTypeApply, migrationsToApply)
+	assert.PanicsWithValue(t, "Could not query versions: get version trouble maker", func() {
+		connector.CreateVersion("commit-sha", types.ActionApply, false, migrationsToApply)
 	})
 
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -384,7 +385,82 @@ func TestApplyMigrationsCommitError(t *testing.T) {
 	}
 }
 
-func TestAddTenantTransactionBeginError(t *testing.T) {
+func TestCreateVersionVersionNotFound(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	assert.Nil(t, err)
+
+	config := &config.Config{}
+	config.Driver = "postgres"
+	dialect := newDialect(config)
+	connector := baseConnector{newTestContext(), config, dialect, db}
+
+	tn := time.Now().UnixNano()
+	m := types.Migration{Name: fmt.Sprintf("%v.sql", tn), SourceDir: "tenants", File: fmt.Sprintf("tenants/%v.sql", tn), MigrationType: types.MigrationTypeTenantMigration, Contents: "insert into {schema}.settings values (456, '456') "}
+	migrationsToApply := []types.Migration{m}
+
+	tenant := "tenantname"
+	tenants := sqlmock.NewRows([]string{"name"}).AddRow(tenant)
+	mock.ExpectQuery("select").WillReturnRows(tenants)
+	mock.ExpectBegin()
+	// version
+	mock.ExpectPrepare("insert into migrator.migrator_versions")
+	mock.ExpectPrepare("insert into migrator.migrator_versions").ExpectQuery().WithArgs("commit-sha")
+	// migration
+	mock.ExpectPrepare("insert into migrator.migrator_migrations")
+	mock.ExpectExec("insert into").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectPrepare("insert into migrator.migrator_migrations").ExpectExec().WithArgs(m.Name, m.SourceDir, m.File, m.MigrationType, tenant, m.Contents, m.CheckSum, 0).WillReturnResult(sqlmock.NewResult(0, 0))
+	// get version
+	rows := sqlmock.NewRows([]string{"vid", "vname", "vcreated", "mid", "name", "source_dir", "filename", "type", "db_schema", "created", "contents", "checksum"})
+	mock.ExpectQuery("select").WillReturnRows(rows)
+
+	assert.PanicsWithValue(t, "Version not found ID: 0", func() {
+		connector.CreateVersion("commit-sha", types.ActionApply, false, migrationsToApply)
+	})
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("there were unfulfilled expectations: %s", err)
+	}
+}
+
+func TestCreateVersionMigrationsCommitError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	assert.Nil(t, err)
+
+	config := &config.Config{}
+	config.Driver = "postgres"
+	dialect := newDialect(config)
+	connector := baseConnector{newTestContext(), config, dialect, db}
+
+	tn := time.Now().UnixNano()
+	m := types.Migration{Name: fmt.Sprintf("%v.sql", tn), SourceDir: "tenants", File: fmt.Sprintf("tenants/%v.sql", tn), MigrationType: types.MigrationTypeTenantMigration, Contents: "insert into {schema}.settings values (456, '456') "}
+	migrationsToApply := []types.Migration{m}
+
+	tenant := "tenantname"
+	tenants := sqlmock.NewRows([]string{"name"}).AddRow(tenant)
+	mock.ExpectQuery("select").WillReturnRows(tenants)
+	mock.ExpectBegin()
+	// version
+	mock.ExpectPrepare("insert into migrator.migrator_versions")
+	mock.ExpectPrepare("insert into migrator.migrator_versions").ExpectQuery().WithArgs("commit-sha")
+	// migration
+	mock.ExpectPrepare("insert into migrator.migrator_migrations")
+	mock.ExpectExec("insert into").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectPrepare("insert into migrator.migrator_migrations").ExpectExec().WithArgs(m.Name, m.SourceDir, m.File, m.MigrationType, tenant, m.Contents, m.CheckSum, 0).WillReturnResult(sqlmock.NewResult(0, 0))
+	// get version
+	rows := sqlmock.NewRows([]string{"vid", "vname", "vcreated", "mid", "name", "source_dir", "filename", "type", "db_schema", "created", "contents", "checksum"}).AddRow("123", "vname", time.Now(), "456", m.Name, m.SourceDir, m.File, m.MigrationType, tenant, time.Now(), m.Contents, m.CheckSum)
+	mock.ExpectQuery("select").WillReturnRows(rows)
+	mock.ExpectCommit().WillReturnError(errors.New("tx trouble maker"))
+
+	assert.PanicsWithValue(t, "Could not commit transaction: tx trouble maker", func() {
+		connector.CreateVersion("commit-sha", types.ActionApply, false, migrationsToApply)
+	})
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("there were unfulfilled expectations: %s", err)
+	}
+}
+
+func TestCreateTenantTransactionBeginError(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	assert.Nil(t, err)
 
@@ -400,7 +476,7 @@ func TestAddTenantTransactionBeginError(t *testing.T) {
 	migrationsToApply := []types.Migration{tenant1}
 
 	assert.PanicsWithValue(t, "Could not start transaction: trouble maker tx.Begin()", func() {
-		connector.AddTenantAndApplyMigrations(types.ModeTypeApply, "newtenant", migrationsToApply)
+		connector.CreateTenant("commit-sha", types.ActionApply, false, "newtenant", migrationsToApply)
 	})
 
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -408,7 +484,7 @@ func TestAddTenantTransactionBeginError(t *testing.T) {
 	}
 }
 
-func TestAddTenantAndApplyMigrationsCreateSchemaError(t *testing.T) {
+func TestCreateTenantCreateSchemaError(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	assert.Nil(t, err)
 
@@ -426,7 +502,7 @@ func TestAddTenantAndApplyMigrationsCreateSchemaError(t *testing.T) {
 	migrationsToApply := []types.Migration{tenant1}
 
 	assert.PanicsWithValue(t, "Create schema failed: trouble maker", func() {
-		connector.AddTenantAndApplyMigrations(types.ModeTypeApply, "newtenant", migrationsToApply)
+		connector.CreateTenant("commit-sha", types.ActionApply, false, "newtenant", migrationsToApply)
 	})
 
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -434,7 +510,7 @@ func TestAddTenantAndApplyMigrationsCreateSchemaError(t *testing.T) {
 	}
 }
 
-func TestAddTenantAndApplyMigrationsInsertTenantPreparedStatementError(t *testing.T) {
+func TestCreateTenantInsertTenantPreparedStatementError(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	assert.Nil(t, err)
 
@@ -453,7 +529,7 @@ func TestAddTenantAndApplyMigrationsInsertTenantPreparedStatementError(t *testin
 	migrationsToApply := []types.Migration{tenant1}
 
 	assert.PanicsWithValue(t, "Could not create prepared statement: trouble maker", func() {
-		connector.AddTenantAndApplyMigrations(types.ModeTypeApply, "newtenant", migrationsToApply)
+		connector.CreateTenant("commit-sha", types.ActionApply, false, "newtenant", migrationsToApply)
 	})
 
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -461,7 +537,7 @@ func TestAddTenantAndApplyMigrationsInsertTenantPreparedStatementError(t *testin
 	}
 }
 
-func TestAddTenantAndApplyMigrationsInsertTenantError(t *testing.T) {
+func TestCreateTenantInsertTenantError(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	assert.Nil(t, err)
 
@@ -483,7 +559,7 @@ func TestAddTenantAndApplyMigrationsInsertTenantError(t *testing.T) {
 	migrationsToApply := []types.Migration{m1}
 
 	assert.PanicsWithValue(t, "Failed to add tenant entry: trouble maker", func() {
-		connector.AddTenantAndApplyMigrations(types.ModeTypeApply, tenant, migrationsToApply)
+		connector.CreateTenant("commit-sha", types.ActionApply, false, tenant, migrationsToApply)
 	})
 
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -491,7 +567,7 @@ func TestAddTenantAndApplyMigrationsInsertTenantError(t *testing.T) {
 	}
 }
 
-func TestAddTenantAndApplyMigrationsCommitError(t *testing.T) {
+func TestCreateTenantCommitError(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	assert.Nil(t, err)
 
@@ -500,8 +576,8 @@ func TestAddTenantAndApplyMigrationsCommitError(t *testing.T) {
 	dialect := newDialect(config)
 	connector := baseConnector{newTestContext(), config, dialect, db}
 
-	time := time.Now().UnixNano()
-	m := types.Migration{Name: fmt.Sprintf("%v.sql", time), SourceDir: "tenants", File: fmt.Sprintf("tenants/%v.sql", time), MigrationType: types.MigrationTypeTenantMigration, Contents: "insert into {schema}.settings values (456, '456') "}
+	tn := time.Now().UnixNano()
+	m := types.Migration{Name: fmt.Sprintf("%v.sql", tn), SourceDir: "tenants", File: fmt.Sprintf("tenants/%v.sql", tn), MigrationType: types.MigrationTypeTenantMigration, Contents: "insert into {schema}.settings values (456, '456') "}
 	migrationsToApply := []types.Migration{m}
 
 	tenant := "tenantname"
@@ -512,15 +588,18 @@ func TestAddTenantAndApplyMigrationsCommitError(t *testing.T) {
 	mock.ExpectPrepare("insert into").ExpectExec().WithArgs(tenant).WillReturnResult(sqlmock.NewResult(0, 0))
 	// version
 	mock.ExpectPrepare("insert into migrator.migrator_versions")
-	mock.ExpectPrepare("insert into migrator.migrator_versions").ExpectQuery().WithArgs("")
+	mock.ExpectPrepare("insert into migrator.migrator_versions").ExpectQuery().WithArgs("commit-sha")
 	// migration
 	mock.ExpectPrepare("insert into migrator.migrator_migrations")
 	mock.ExpectExec("insert into").WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectPrepare("insert into").ExpectExec().WithArgs(m.Name, m.SourceDir, m.File, m.MigrationType, tenant, m.Contents, m.CheckSum, 0).WillReturnResult(sqlmock.NewResult(0, 0))
+	// get version
+	rows := sqlmock.NewRows([]string{"vid", "vname", "vcreated", "mid", "name", "source_dir", "filename", "type", "db_schema", "created", "contents", "checksum"}).AddRow("123", "vname", time.Now(), "456", m.Name, m.SourceDir, m.File, m.MigrationType, tenant, time.Now(), m.Contents, m.CheckSum)
+	mock.ExpectQuery("select").WillReturnRows(rows)
 	mock.ExpectCommit().WillReturnError(errors.New("tx trouble maker"))
 
 	assert.PanicsWithValue(t, "Could not commit transaction: tx trouble maker", func() {
-		connector.AddTenantAndApplyMigrations(types.ModeTypeApply, tenant, migrationsToApply)
+		connector.CreateTenant("commit-sha", types.ActionApply, false, tenant, migrationsToApply)
 	})
 
 	if err := mock.ExpectationsWereMet(); err != nil {

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -72,7 +72,7 @@ func TestGetTenants(t *testing.T) {
 	assert.Contains(t, tenants, types.Tenant{Name: "xyz"})
 }
 
-func TestApplyMigrations(t *testing.T) {
+func TestCreateVersion(t *testing.T) {
 	config, err := config.FromFile("../test/migrator.yaml")
 	assert.Nil(t, err)
 
@@ -114,17 +114,21 @@ func TestApplyMigrations(t *testing.T) {
 
 	migrationsToApply := []types.Migration{public1, public2, public3, tenant1, tenant2, tenant3, public4, public5, tenant4}
 
-	results := connector.ApplyMigrations(types.ModeTypeApply, migrationsToApply)
+	results, version := connector.CreateVersion("commit-sha", types.ActionApply, false, migrationsToApply)
 
-	assert.Equal(t, noOfTenants, results.Tenants)
-	assert.Equal(t, 3, results.SingleMigrations)
-	assert.Equal(t, 2, results.SingleScripts)
-	assert.Equal(t, 3, results.TenantMigrations)
-	assert.Equal(t, 1, results.TenantScripts)
-	assert.Equal(t, noOfTenants*3, results.TenantMigrationsTotal)
-	assert.Equal(t, noOfTenants*1, results.TenantScriptsTotal)
-	assert.Equal(t, noOfTenants*3+3, results.MigrationsGrandTotal)
-	assert.Equal(t, noOfTenants*1+2, results.ScriptsGrandTotal)
+	assert.NotNil(t, version)
+	assert.True(t, version.ID > 0)
+	assert.Equal(t, "commit-sha", version.Name)
+	assert.Equal(t, results.MigrationsGrandTotal+results.ScriptsGrandTotal, int32(len(version.DBMigrations)))
+	assert.Equal(t, int32(noOfTenants), results.Tenants)
+	assert.Equal(t, int32(3), results.SingleMigrations)
+	assert.Equal(t, int32(2), results.SingleScripts)
+	assert.Equal(t, int32(3), results.TenantMigrations)
+	assert.Equal(t, int32(1), results.TenantScripts)
+	assert.Equal(t, int32(noOfTenants*3), results.TenantMigrationsTotal)
+	assert.Equal(t, int32(noOfTenants*1), results.TenantScriptsTotal)
+	assert.Equal(t, int32(noOfTenants*3+3), results.MigrationsGrandTotal)
+	assert.Equal(t, int32(noOfTenants*1+2), results.ScriptsGrandTotal)
 
 	dbMigrationsAfter := connector.GetAppliedMigrations()
 	lenAfter := len(dbMigrationsAfter)
@@ -135,7 +139,7 @@ func TestApplyMigrations(t *testing.T) {
 	assert.Equal(t, expected, lenAfter-lenBefore)
 }
 
-func TestApplyMigrationsEmptyMigrationArray(t *testing.T) {
+func TestCreateVersionEmptyMigrationArray(t *testing.T) {
 	config, err := config.FromFile("../test/migrator.yaml")
 	assert.Nil(t, err)
 
@@ -144,13 +148,14 @@ func TestApplyMigrationsEmptyMigrationArray(t *testing.T) {
 
 	migrationsToApply := []types.Migration{}
 
-	results := connector.ApplyMigrations(types.ModeTypeApply, migrationsToApply)
-
-	assert.Equal(t, 0, results.MigrationsGrandTotal)
-	assert.Equal(t, 0, results.ScriptsGrandTotal)
+	results, version := connector.CreateVersion("commit-sha", types.ActionApply, false, migrationsToApply)
+	// empty migrations slice - no version created
+	assert.Nil(t, version)
+	assert.Equal(t, int32(0), results.MigrationsGrandTotal)
+	assert.Equal(t, int32(0), results.ScriptsGrandTotal)
 }
 
-func TestApplyMigrationsDryRunMode(t *testing.T) {
+func TestCreateVersionDryRunMode(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	assert.Nil(t, err)
 
@@ -159,8 +164,8 @@ func TestApplyMigrationsDryRunMode(t *testing.T) {
 	dialect := newDialect(config)
 	connector := baseConnector{newTestContext(), config, dialect, db}
 
-	time := time.Now().UnixNano()
-	m := types.Migration{Name: fmt.Sprintf("%v.sql", time), SourceDir: "tenants", File: fmt.Sprintf("tenants/%v.sql", time), MigrationType: types.MigrationTypeTenantMigration, Contents: "insert into {schema}.settings values (456, '456') "}
+	tn := time.Now().UnixNano()
+	m := types.Migration{Name: fmt.Sprintf("%v.sql", tn), SourceDir: "tenants", File: fmt.Sprintf("tenants/%v.sql", tn), MigrationType: types.MigrationTypeTenantMigration, Contents: "insert into {schema}.settings values (456, '456') "}
 	migrationsToApply := []types.Migration{m}
 
 	tenant := "tenantname"
@@ -169,26 +174,30 @@ func TestApplyMigrationsDryRunMode(t *testing.T) {
 	mock.ExpectBegin()
 	// version
 	mock.ExpectPrepare("insert into migrator.migrator_versions")
-	mock.ExpectPrepare("insert into migrator.migrator_versions").ExpectQuery().WithArgs("")
+	mock.ExpectPrepare("insert into migrator.migrator_versions").ExpectQuery().WithArgs("commit-sha")
 	// migration
 	mock.ExpectPrepare("insert into migrator.migrator_migrations")
 	mock.ExpectExec("insert into").WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectPrepare("insert into migrator.migrator_migrations").ExpectExec().WithArgs(m.Name, m.SourceDir, m.File, m.MigrationType, tenant, m.Contents, m.CheckSum, 0).WillReturnResult(sqlmock.NewResult(0, 0))
-
+	// get version
+	rows := sqlmock.NewRows([]string{"vid", "vname", "vcreated", "mid", "name", "source_dir", "filename", "type", "db_schema", "created", "contents", "checksum"}).AddRow("123", "vname", time.Now(), "456", m.Name, m.SourceDir, m.File, m.MigrationType, tenant, time.Now(), m.Contents, m.CheckSum)
+	mock.ExpectQuery("select").WillReturnRows(rows)
 	// dry-run mode calls rollback instead of commit
 	mock.ExpectRollback()
 
 	// however the results contain correct dry-run data like number of applied migrations/scripts
-	results := connector.ApplyMigrations(types.ModeTypeDryRun, migrationsToApply)
-
-	assert.Equal(t, 1, results.MigrationsGrandTotal)
+	results, version := connector.CreateVersion("commit-sha", types.ActionApply, true, migrationsToApply)
+	assert.NotNil(t, version)
+	assert.True(t, version.ID > 0)
+	assert.Equal(t, results.MigrationsGrandTotal+results.ScriptsGrandTotal, int32(len(version.DBMigrations)))
+	assert.Equal(t, int32(1), results.MigrationsGrandTotal)
 
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Errorf("there were unfulfilled expectations: %s", err)
 	}
 }
 
-func TestApplyMigrationsSyncMode(t *testing.T) {
+func TestCreateVersionSyncMode(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	assert.Nil(t, err)
 
@@ -197,8 +206,8 @@ func TestApplyMigrationsSyncMode(t *testing.T) {
 	dialect := newDialect(config)
 	connector := baseConnector{newTestContext(), config, dialect, db}
 
-	time := time.Now().UnixNano()
-	m := types.Migration{Name: fmt.Sprintf("%v.sql", time), SourceDir: "tenants", File: fmt.Sprintf("tenants/%v.sql", time), MigrationType: types.MigrationTypeTenantMigration, Contents: "insert into {schema}.settings values (456, '456') "}
+	tn := time.Now().UnixNano()
+	m := types.Migration{Name: fmt.Sprintf("%v.sql", tn), SourceDir: "tenants", File: fmt.Sprintf("tenants/%v.sql", tn), MigrationType: types.MigrationTypeTenantMigration, Contents: "insert into {schema}.settings values (456, '456') "}
 	migrationsToApply := []types.Migration{m}
 
 	tenant := "tenantname"
@@ -207,16 +216,21 @@ func TestApplyMigrationsSyncMode(t *testing.T) {
 	mock.ExpectBegin()
 	// version
 	mock.ExpectPrepare("insert into migrator.migrator_versions")
-	mock.ExpectPrepare("insert into migrator.migrator_versions").ExpectQuery().WithArgs("")
+	mock.ExpectPrepare("insert into migrator.migrator_versions").ExpectQuery().WithArgs("commit-sha")
 	// migration
 	mock.ExpectPrepare("insert into migrator.migrator_migrations")
 	mock.ExpectPrepare("insert into").ExpectExec().WithArgs(m.Name, m.SourceDir, m.File, m.MigrationType, tenant, m.Contents, m.CheckSum, 0).WillReturnResult(sqlmock.NewResult(0, 0))
+	// get version
+	rows := sqlmock.NewRows([]string{"vid", "vname", "vcreated", "mid", "name", "source_dir", "filename", "type", "db_schema", "created", "contents", "checksum"}).AddRow("123", "vname", time.Now(), "456", m.Name, m.SourceDir, m.File, m.MigrationType, tenant, time.Now(), m.Contents, m.CheckSum)
+	mock.ExpectQuery("select").WillReturnRows(rows)
 	mock.ExpectCommit()
 
 	// sync the results contain correct data like number of applied migrations/scripts
-	results := connector.ApplyMigrations(types.ModeTypeSync, migrationsToApply)
-
-	assert.Equal(t, 1, results.MigrationsGrandTotal)
+	results, version := connector.CreateVersion("commit-sha", types.ActionSync, false, migrationsToApply)
+	assert.NotNil(t, version)
+	assert.True(t, version.ID > 0)
+	assert.Equal(t, results.MigrationsGrandTotal+results.ScriptsGrandTotal, int32(len(version.DBMigrations)))
+	assert.Equal(t, int32(1), results.MigrationsGrandTotal)
 
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Errorf("there were unfulfilled expectations: %s", err)
@@ -275,7 +289,7 @@ func TestGetSchemaPlaceHolderOverride(t *testing.T) {
 	assert.Equal(t, "[schema]", placeholder)
 }
 
-func TestAddTenantAndApplyMigrations(t *testing.T) {
+func TestCreateTenant(t *testing.T) {
 	config, err := config.FromFile("../test/migrator.yaml")
 	assert.Nil(t, err)
 
@@ -294,16 +308,21 @@ func TestAddTenantAndApplyMigrations(t *testing.T) {
 
 	uniqueTenant := fmt.Sprintf("new_test_tenant_%v", time.Now().UnixNano())
 
-	results := connector.AddTenantAndApplyMigrations(types.ModeTypeApply, uniqueTenant, migrationsToApply)
+	results, version := connector.CreateTenant("commit-sha", types.ActionApply, false, uniqueTenant, migrationsToApply)
+
+	assert.NotNil(t, version)
+	assert.True(t, version.ID > 0)
+	assert.Equal(t, "commit-sha", version.Name)
+	assert.Equal(t, results.MigrationsGrandTotal+results.ScriptsGrandTotal, int32(len(version.DBMigrations)))
 
 	// applied only for one tenant - the newly added one
-	assert.Equal(t, 1, results.Tenants)
+	assert.Equal(t, int32(1), results.Tenants)
 	// just one tenant so total number of tenant migrations is equal to tenant migrations
-	assert.Equal(t, 3, results.TenantMigrations)
-	assert.Equal(t, 3, results.TenantMigrationsTotal)
+	assert.Equal(t, int32(3), results.TenantMigrations)
+	assert.Equal(t, int32(3), results.TenantMigrationsTotal)
 }
 
-func TestAddTenantAndApplyMigrationsDryRunMode(t *testing.T) {
+func TestCreateTenantDryRunMode(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	assert.Nil(t, err)
 
@@ -312,8 +331,8 @@ func TestAddTenantAndApplyMigrationsDryRunMode(t *testing.T) {
 	dialect := newDialect(config)
 	connector := baseConnector{newTestContext(), config, dialect, db}
 
-	time := time.Now().UnixNano()
-	m := types.Migration{Name: fmt.Sprintf("%v.sql", time), SourceDir: "tenants", File: fmt.Sprintf("tenants/%v.sql", time), MigrationType: types.MigrationTypeTenantMigration, Contents: "insert into {schema}.settings values (456, '456') "}
+	tn := time.Now().UnixNano()
+	m := types.Migration{Name: fmt.Sprintf("%v.sql", tn), SourceDir: "tenants", File: fmt.Sprintf("tenants/%v.sql", tn), MigrationType: types.MigrationTypeTenantMigration, Contents: "insert into {schema}.settings values (456, '456') "}
 	migrationsToApply := []types.Migration{m}
 
 	tenant := "tenantname"
@@ -325,26 +344,30 @@ func TestAddTenantAndApplyMigrationsDryRunMode(t *testing.T) {
 	mock.ExpectPrepare("insert into").ExpectExec().WithArgs(tenant).WillReturnResult(sqlmock.NewResult(1, 1))
 	// version
 	mock.ExpectPrepare("insert into migrator.migrator_versions")
-	mock.ExpectPrepare("insert into migrator.migrator_versions").ExpectQuery().WithArgs("")
+	mock.ExpectPrepare("insert into migrator.migrator_versions").ExpectQuery().WithArgs("commit-sha")
 	// migration
 	mock.ExpectPrepare("insert into migrator.migrator_migrations")
 	mock.ExpectExec("insert into").WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectPrepare("insert into migrator.migrator_migrations").ExpectExec().WithArgs(m.Name, m.SourceDir, m.File, m.MigrationType, tenant, m.Contents, m.CheckSum, 0).WillReturnResult(sqlmock.NewResult(0, 0))
-
+	// get version
+	rows := sqlmock.NewRows([]string{"vid", "vname", "vcreated", "mid", "name", "source_dir", "filename", "type", "db_schema", "created", "contents", "checksum"}).AddRow("123", "vname", time.Now(), "456", m.Name, m.SourceDir, m.File, m.MigrationType, tenant, time.Now(), m.Contents, m.CheckSum)
+	mock.ExpectQuery("select").WillReturnRows(rows)
 	// dry-run mode calls rollback instead of commit
 	mock.ExpectRollback()
 
 	// however the results contain correct dry-run data like number of applied migrations/scripts
-	results := connector.AddTenantAndApplyMigrations(types.ModeTypeDryRun, tenant, migrationsToApply)
-
-	assert.Equal(t, 1, results.MigrationsGrandTotal)
+	results, version := connector.CreateTenant("commit-sha", types.ActionApply, true, tenant, migrationsToApply)
+	assert.NotNil(t, version)
+	assert.True(t, version.ID > 0)
+	assert.Equal(t, results.MigrationsGrandTotal+results.ScriptsGrandTotal, int32(len(version.DBMigrations)))
+	assert.Equal(t, int32(1), results.MigrationsGrandTotal)
 
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Errorf("there were unfulfilled expectations: %s", err)
 	}
 }
 
-func TestAddTenantAndApplyMigrationsSyncMode(t *testing.T) {
+func TestCreateTenantSyncMode(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	assert.Nil(t, err)
 
@@ -353,8 +376,8 @@ func TestAddTenantAndApplyMigrationsSyncMode(t *testing.T) {
 	dialect := newDialect(config)
 	connector := baseConnector{newTestContext(), config, dialect, db}
 
-	time := time.Now().UnixNano()
-	m := types.Migration{Name: fmt.Sprintf("%v.sql", time), SourceDir: "tenants", File: fmt.Sprintf("tenants/%v.sql", time), MigrationType: types.MigrationTypeTenantMigration, Contents: "insert into {schema}.settings values (456, '456') "}
+	tn := time.Now().UnixNano()
+	m := types.Migration{Name: fmt.Sprintf("%v.sql", tn), SourceDir: "tenants", File: fmt.Sprintf("tenants/%v.sql", tn), MigrationType: types.MigrationTypeTenantMigration, Contents: "insert into {schema}.settings values (456, '456') "}
 	migrationsToApply := []types.Migration{m}
 
 	tenant := "tenantname"
@@ -365,16 +388,21 @@ func TestAddTenantAndApplyMigrationsSyncMode(t *testing.T) {
 	mock.ExpectPrepare("insert into").ExpectExec().WithArgs(tenant).WillReturnResult(sqlmock.NewResult(0, 0))
 	// version
 	mock.ExpectPrepare("insert into migrator.migrator_versions")
-	mock.ExpectPrepare("insert into migrator.migrator_versions").ExpectQuery().WithArgs("")
+	mock.ExpectPrepare("insert into migrator.migrator_versions").ExpectQuery().WithArgs("commit-sha")
 	// migration
 	mock.ExpectPrepare("insert into migrator.migrator_migrations")
 	mock.ExpectPrepare("insert into").ExpectExec().WithArgs(m.Name, m.SourceDir, m.File, m.MigrationType, tenant, m.Contents, m.CheckSum, 0).WillReturnResult(sqlmock.NewResult(0, 0))
+	// get version
+	rows := sqlmock.NewRows([]string{"vid", "vname", "vcreated", "mid", "name", "source_dir", "filename", "type", "db_schema", "created", "contents", "checksum"}).AddRow("123", "vname", time.Now(), "456", m.Name, m.SourceDir, m.File, m.MigrationType, tenant, time.Now(), m.Contents, m.CheckSum)
+	mock.ExpectQuery("select").WillReturnRows(rows)
 	mock.ExpectCommit()
 
 	// sync results contain correct data like number of applied migrations/scripts
-	results := connector.AddTenantAndApplyMigrations(types.ModeTypeSync, tenant, migrationsToApply)
-
-	assert.Equal(t, 1, results.MigrationsGrandTotal)
+	results, version := connector.CreateTenant("commit-sha", types.ActionSync, false, tenant, migrationsToApply)
+	assert.NotNil(t, version)
+	assert.True(t, version.ID > 0)
+	assert.Equal(t, results.MigrationsGrandTotal+results.ScriptsGrandTotal, int32(len(version.DBMigrations)))
+	assert.Equal(t, int32(1), results.MigrationsGrandTotal)
 
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Errorf("there were unfulfilled expectations: %s", err)

--- a/server/server_mocks.go
+++ b/server/server_mocks.go
@@ -31,6 +31,14 @@ func newMockedErrorCoordinator(errorThreshold int) func(context.Context, *config
 func (m *mockedCoordinator) Dispose() {
 }
 
+func (m *mockedCoordinator) CreateTenant(string, types.Action, bool, string) *types.CreateResults {
+	return &types.CreateResults{Summary: &types.MigrationResults{}, Version: &types.Version{}}
+}
+
+func (m *mockedCoordinator) CreateVersion(string, types.Action, bool) *types.CreateResults {
+	return &types.CreateResults{Summary: &types.MigrationResults{}, Version: &types.Version{}}
+}
+
 func (m *mockedCoordinator) GetSourceMigrations(_ *coordinator.SourceMigrationFilters) []types.Migration {
 	if m.errorThreshold == m.counter {
 		panic(fmt.Sprintf("Mocked Error Disk Loader: threshold %v reached", m.errorThreshold))

--- a/types/types.go
+++ b/types/types.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/graph-gophers/graphql-go"
 	"gopkg.in/go-playground/validator.v9"
@@ -40,7 +39,7 @@ func (t MigrationType) String() string {
 	case MigrationTypeTenantScript:
 		return "TenantScript"
 	default:
-		panic(fmt.Sprintf("Unknown migration type value: %v", uint32(t)))
+		panic(fmt.Sprintf("Unknown MigrationType value: %v", uint32(t)))
 	}
 }
 
@@ -57,7 +56,7 @@ func (t *MigrationType) UnmarshalGraphQL(input interface{}) error {
 		case "TenantScript":
 			*t = MigrationTypeTenantScript
 		default:
-			panic(fmt.Sprintf("Unknown migration type literal: %v", str))
+			panic(fmt.Sprintf("Unknown MigrationType literal: %v", str))
 		}
 		return nil
 	}
@@ -150,19 +149,88 @@ type MigrationDB struct {
 	Created graphql.Time `json:"created"`
 }
 
+// Summary contains summary information about created version
+// replaces deprecated MigrationDB
+type Summary = MigrationResults
+
 // MigrationResults contains summary information about executed migrations
+// deprecated in v2020.1.0 sunset in v2021.1.0
+// replaced by Stats
 type MigrationResults struct {
-	StartedAt             time.Time     `json:"startedAt"`
-	Duration              time.Duration `json:"duration"`
-	Tenants               int           `json:"tenants"`
-	SingleMigrations      int           `json:"singleMigrations"`
-	TenantMigrations      int           `json:"tenantMigrations"`
-	TenantMigrationsTotal int           `json:"tenantMigrationsTotal"` // tenant migrations for all tenants
-	MigrationsGrandTotal  int           `json:"migrationsGrandTotal"`  // total number of all migrations applied
-	SingleScripts         int           `json:"singleScripts"`
-	TenantScripts         int           `json:"tenantScripts"`
-	TenantScriptsTotal    int           `json:"tenantScriptsTotal"` // tenant scripts for all tenants
-	ScriptsGrandTotal     int           `json:"scriptsGrandTotal"`  // total number of all scripts applied
+	StartedAt             graphql.Time `json:"startedAt"`
+	Duration              int32        `json:"duration"`
+	Tenants               int32        `json:"tenants"`
+	SingleMigrations      int32        `json:"singleMigrations"`
+	TenantMigrations      int32        `json:"tenantMigrations"`
+	TenantMigrationsTotal int32        `json:"tenantMigrationsTotal"` // tenant migrations for all tenants
+	MigrationsGrandTotal  int32        `json:"migrationsGrandTotal"`  // total number of all migrations applied
+	SingleScripts         int32        `json:"singleScripts"`
+	TenantScripts         int32        `json:"tenantScripts"`
+	TenantScriptsTotal    int32        `json:"tenantScriptsTotal"` // tenant scripts for all tenants
+	ScriptsGrandTotal     int32        `json:"scriptsGrandTotal"`  // total number of all scripts applied
+}
+
+// CreateResults contains results of CreateVersion or CreateTenant
+type CreateResults struct {
+	Summary *Summary
+	Version *Version
+}
+
+// Action stores information about migrator action
+type Action int
+
+const (
+	// ActionApply (the default action) tells migrator to apply all source migrations
+	ActionApply Action = iota
+	// ActionSync tells migrator to synchronise source migrations and not apply them
+	ActionSync
+)
+
+// ImplementsGraphQLType maps Action Go type
+// to the graphql scalar type in the schema
+func (Action) ImplementsGraphQLType(name string) bool {
+	return name == "Action"
+}
+
+// String converts MigrationType Go type to string literal
+func (a Action) String() string {
+	switch a {
+	case ActionSync:
+		return "Sync"
+	case ActionApply:
+		return "Apply"
+	default:
+		panic(fmt.Sprintf("Unknown Action value: %v", uint32(a)))
+	}
+}
+
+// UnmarshalGraphQL converts string literal to MigrationType Go type
+func (a *Action) UnmarshalGraphQL(input interface{}) error {
+	if str, ok := input.(string); ok {
+		switch str {
+		case "Sync":
+			*a = ActionSync
+		case "Apply":
+			*a = ActionApply
+		default:
+			panic(fmt.Sprintf("Unknown Action literal: %v", str))
+		}
+		return nil
+	}
+	return fmt.Errorf("Wrong type for Action: %T", input)
+}
+
+type VersionInput struct {
+	VersionName string
+	Action      Action
+	DryRun      bool
+}
+
+type TenantInput struct {
+	VersionName string
+	Action      Action
+	DryRun      bool
+	TenantName  string
 }
 
 // VersionInfo contains build information and supported API versions


### PR DESCRIPTION
Implemented GraphQL operations createVersion and createTenant together with all backing services. 

Middleware code is far from perfect but v1 and v2 are working side-by-side. Middleware will be refactored and clean up when v1 will sunset (planned sunset: v2021.1.0).