### PR TITLE
posgresql-ddl

### DIFF
--- a/db/db_postgresql.go
+++ b/db/db_postgresql.go
@@ -24,7 +24,7 @@ if not exists (select * from information_schema.tables where table_schema = '%v'
   create table %v.%v (
     id serial primary key,
     name varchar(200) not null,
-    created timestamp default now()
+    created timestamp with time zone default now()
   );
   alter table %v.%v add column version_id integer;
   create index migrator_versions_version_id_idx on %v.%v (version_id);

--- a/db/db_postgresql_test.go
+++ b/db/db_postgresql_test.go
@@ -81,7 +81,7 @@ if not exists (select * from information_schema.tables where table_schema = 'mig
   create table migrator.migrator_versions (
     id serial primary key,
     name varchar(200) not null,
-    created timestamp default now()
+    created timestamp with time zone default now()
   );
   alter table migrator.migrator_migrations add column version_id integer;
   create index migrator_versions_version_id_idx on migrator.migrator_migrations (version_id);


### PR DESCRIPTION
* Change SQL for PostgreSQL so it conforms with PostgreSQL's best practices.

This is change removes an inconsistency in _migrator.migrator_versions_ between a column's type and its default value.

See also:
- Best practices: https://wiki.postgresql.org/wiki/Don't_Do_This#Don.27t_use_timestamp_.28without_time_zone.29
- The signature of now(): https://www.postgresql.org/docs/9.3/functions-datetime.html#FUNCTIONS-DATETIME-TABLE