### PR TITLE
v2020.1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ services:
   - mysql
 
 go:
-  - "1.12"
   - "1.13"
 
 before_script:

--- a/db/db_postgresql.go
+++ b/db/db_postgresql.go
@@ -24,7 +24,7 @@ if not exists (select * from information_schema.tables where table_schema = '%v'
   create table %v.%v (
     id serial primary key,
     name varchar(200) not null,
-    created timestamp default now()
+    created timestamp with time zone default now()
   );
   alter table %v.%v add column version_id integer;
   create index migrator_versions_version_id_idx on %v.%v (version_id);

--- a/db/db_postgresql_test.go
+++ b/db/db_postgresql_test.go
@@ -81,7 +81,7 @@ if not exists (select * from information_schema.tables where table_schema = 'mig
   create table migrator.migrator_versions (
     id serial primary key,
     name varchar(200) not null,
-    created timestamp default now()
+    created timestamp with time zone default now()
   );
   alter table migrator.migrator_migrations add column version_id integer;
   create index migrator_versions_version_id_idx on migrator.migrator_migrations (version_id);


### PR DESCRIPTION
v2020.1.1 comes with the following minor changes:

* dropping support for go 1.12 due to Azure SDK compile errors
* migrator timestamp columns now have  time zone enabled