### PR TITLE
Create tenant sql injection validation

### DIFF
--- a/coordinator/coordinator.go
+++ b/coordinator/coordinator.go
@@ -157,7 +157,7 @@ func (c *coordinator) ApplyMigrations(mode types.MigrationsModeType) (*types.Mig
 	migrationsToApply := c.computeMigrationsToApply(sourceMigrations, appliedMigrations)
 	common.LogInfo(c.ctx, "Found migrations to apply: %d", len(migrationsToApply))
 
-	results, _ := c.connector.CreateVersion(versionName, action, dryRun, migrationsToApply)
+	results, _ := c.connector.CreateVersion(versionName, action, migrationsToApply, dryRun)
 
 	c.sendNotification(results)
 
@@ -171,7 +171,7 @@ func (c *coordinator) CreateVersion(versionName string, action types.Action, dry
 	migrationsToApply := c.computeMigrationsToApply(sourceMigrations, appliedMigrations)
 	common.LogInfo(c.ctx, "Found migrations to apply: %d", len(migrationsToApply))
 
-	summary, version := c.connector.CreateVersion(versionName, action, dryRun, migrationsToApply)
+	summary, version := c.connector.CreateVersion(versionName, action, migrationsToApply, dryRun)
 
 	c.sendNotification(summary)
 
@@ -195,7 +195,7 @@ func (c *coordinator) AddTenantAndApplyMigrations(mode types.MigrationsModeType,
 	migrationsToApply := c.filterTenantMigrations(sourceMigrations)
 	common.LogInfo(c.ctx, "Migrations to apply for new tenant: %d", len(migrationsToApply))
 
-	summary, _ := c.connector.CreateTenant(versionName, action, dryRun, tenant, migrationsToApply)
+	summary, _ := c.connector.CreateTenant(tenant, versionName, action, migrationsToApply, dryRun)
 
 	c.sendNotification(summary)
 
@@ -209,7 +209,7 @@ func (c *coordinator) CreateTenant(versionName string, action types.Action, dryR
 	migrationsToApply := c.filterTenantMigrations(sourceMigrations)
 	common.LogInfo(c.ctx, "Migrations to apply for new tenant: %d", len(migrationsToApply))
 
-	summary, version := c.connector.CreateTenant(versionName, action, dryRun, tenant, migrationsToApply)
+	summary, version := c.connector.CreateTenant(tenant, versionName, action, migrationsToApply, dryRun)
 
 	c.sendNotification(summary)
 

--- a/coordinator/coordinator_mocks.go
+++ b/coordinator/coordinator_mocks.go
@@ -86,11 +86,11 @@ type mockedConnector struct {
 func (m *mockedConnector) Dispose() {
 }
 
-func (m *mockedConnector) CreateTenant(string, types.Action, bool, string, []types.Migration) (*types.MigrationResults, *types.Version) {
+func (m *mockedConnector) CreateTenant(string, string, types.Action, []types.Migration, bool) (*types.MigrationResults, *types.Version) {
 	return &types.MigrationResults{}, &types.Version{}
 }
 
-func (m *mockedConnector) CreateVersion(string, types.Action, bool, []types.Migration) (*types.MigrationResults, *types.Version) {
+func (m *mockedConnector) CreateVersion(string, types.Action, []types.Migration, bool) (*types.MigrationResults, *types.Version) {
 	return &types.MigrationResults{}, &types.Version{}
 }
 

--- a/db/db.go
+++ b/db/db.go
@@ -25,8 +25,8 @@ type Connector interface {
 	GetDBMigrationByID(ID int32) (*types.DBMigration, error)
 	// deprecated in v2020.1.0 sunset in v2021.1.0
 	GetAppliedMigrations() []types.MigrationDB
-	CreateVersion(string, types.Action, bool, []types.Migration) (*types.MigrationResults, *types.Version)
-	CreateTenant(string, types.Action, bool, string, []types.Migration) (*types.MigrationResults, *types.Version)
+	CreateVersion(string, types.Action, []types.Migration, bool) (*types.MigrationResults, *types.Version)
+	CreateTenant(string, string, types.Action, []types.Migration, bool) (*types.MigrationResults, *types.Version)
 	Dispose()
 }
 
@@ -320,7 +320,7 @@ func (bc *baseConnector) GetAppliedMigrations() []types.MigrationDB {
 }
 
 // CreateVersion creates new DB version and applies passed migrations
-func (bc *baseConnector) CreateVersion(versionName string, action types.Action, dryRun bool, migrations []types.Migration) (*types.MigrationResults, *types.Version) {
+func (bc *baseConnector) CreateVersion(versionName string, action types.Action, migrations []types.Migration, dryRun bool) (*types.MigrationResults, *types.Version) {
 	if len(migrations) == 0 {
 		return &types.MigrationResults{
 			StartedAt: graphql.Time{Time: time.Now()},
@@ -361,7 +361,7 @@ func (bc *baseConnector) CreateVersion(versionName string, action types.Action, 
 }
 
 // CreateTenant creates new tenant and applies passed tenant migrations
-func (bc *baseConnector) CreateTenant(versionName string, action types.Action, dryRun bool, tenant string, migrations []types.Migration) (*types.MigrationResults, *types.Version) {
+func (bc *baseConnector) CreateTenant(tenant string, versionName string, action types.Action, migrations []types.Migration, dryRun bool) (*types.MigrationResults, *types.Version) {
 	tenantInsertSQL := bc.getTenantInsertSQL()
 
 	tx, err := bc.db.Begin()

--- a/db/db_dialect.go
+++ b/db/db_dialect.go
@@ -2,9 +2,12 @@ package db
 
 import (
 	"fmt"
+	"regexp"
 
 	"github.com/lukaszbudnik/migrator/config"
 )
+
+var isValidIdentifier = regexp.MustCompile(`^[A-Za-z0-9_-]+$`).MatchString
 
 // dialect returns SQL statements for given DB
 type dialect interface {
@@ -82,6 +85,9 @@ func (bd *baseDialect) GetMigrationSelectSQL() string {
 // GetCreateSchemaSQL returns create schema SQL statement.
 // This SQL is used by both MySQL and PostgreSQL.
 func (bd *baseDialect) GetCreateSchemaSQL(schema string) string {
+	if !isValidIdentifier(schema) {
+		panic(fmt.Sprintf("Schema name contains invalid characters: %v", schema))
+	}
 	return fmt.Sprintf(createSchemaSQL, schema)
 }
 

--- a/db/db_dialect_test.go
+++ b/db/db_dialect_test.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/lukaszbudnik/migrator/config"
@@ -62,6 +63,17 @@ func TestBaseDialectGetCreateSchemaSQL(t *testing.T) {
 	expected := "create schema if not exists abc"
 
 	assert.Equal(t, expected, createSchemaSQL)
+}
+
+func TestBaseDialectGetCreateSchemaSQLError(t *testing.T) {
+	config, err := config.FromFile("../test/migrator-postgresql.yaml")
+	assert.Nil(t, err)
+
+	dialect := newDialect(config)
+
+	sqlInjection := "abc; drop schema migrator;"
+	expectedValue := fmt.Sprintf("Schema name contains invalid characters: %v", sqlInjection)
+	assert.PanicsWithValue(t, expectedValue, func() { dialect.GetCreateSchemaSQL(sqlInjection) })
 }
 
 func TestBaseDialectGetVersionsSelectSQL(t *testing.T) {

--- a/db/db_error_handling_test.go
+++ b/db/db_error_handling_test.go
@@ -213,7 +213,7 @@ func TestCreateVersionTransactionBeginError(t *testing.T) {
 	migrationsToApply := []types.Migration{tenant1}
 
 	assert.PanicsWithValue(t, "Could not start transaction: trouble maker tx.Begin()", func() {
-		connector.CreateVersion("commit-sha", types.ActionApply, false, migrationsToApply)
+		connector.CreateVersion("commit-sha", types.ActionApply, migrationsToApply, false)
 	})
 
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -241,7 +241,7 @@ func TestCreateVersionInsertVersionPreparedStatementError(t *testing.T) {
 	migrationsToApply := []types.Migration{tenant1}
 
 	assert.PanicsWithValue(t, "Could not create prepared statement for version: trouble maker", func() {
-		connector.CreateVersion("commit-sha", types.ActionApply, false, migrationsToApply)
+		connector.CreateVersion("commit-sha", types.ActionApply, migrationsToApply, false)
 	})
 
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -273,7 +273,7 @@ func TestCreateVersionInsertMigrationPreparedStatementError(t *testing.T) {
 	migrationsToApply := []types.Migration{tenant1}
 
 	assert.PanicsWithValue(t, "Could not create prepared statement for migration: trouble maker", func() {
-		connector.CreateVersion("commit-sha", types.ActionApply, false, migrationsToApply)
+		connector.CreateVersion("commit-sha", types.ActionApply, migrationsToApply, false)
 	})
 
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -306,7 +306,7 @@ func TestCreateVersionMigrationSQLError(t *testing.T) {
 	migrationsToApply := []types.Migration{tenant1}
 
 	assert.PanicsWithValue(t, fmt.Sprintf("SQL migration %v failed with error: trouble maker", tenant1.File), func() {
-		connector.CreateVersion("commit-sha", types.ActionApply, false, migrationsToApply)
+		connector.CreateVersion("commit-sha", types.ActionApply, migrationsToApply, false)
 	})
 
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -341,7 +341,7 @@ func TestCreateVersionInsertMigrationError(t *testing.T) {
 	mock.ExpectRollback()
 
 	assert.PanicsWithValue(t, "Failed to add migration entry: trouble maker", func() {
-		connector.CreateVersion("commit-sha", types.ActionApply, false, migrationsToApply)
+		connector.CreateVersion("commit-sha", types.ActionApply, migrationsToApply, false)
 	})
 
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -377,7 +377,7 @@ func TestCreateVersionGetVersionError(t *testing.T) {
 	mock.ExpectQuery("select").WillReturnError(errors.New("get version trouble maker"))
 
 	assert.PanicsWithValue(t, "Could not query versions: get version trouble maker", func() {
-		connector.CreateVersion("commit-sha", types.ActionApply, false, migrationsToApply)
+		connector.CreateVersion("commit-sha", types.ActionApply, migrationsToApply, false)
 	})
 
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -414,7 +414,7 @@ func TestCreateVersionVersionNotFound(t *testing.T) {
 	mock.ExpectQuery("select").WillReturnRows(rows)
 
 	assert.PanicsWithValue(t, "Version not found ID: 0", func() {
-		connector.CreateVersion("commit-sha", types.ActionApply, false, migrationsToApply)
+		connector.CreateVersion("commit-sha", types.ActionApply, migrationsToApply, false)
 	})
 
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -452,7 +452,7 @@ func TestCreateVersionMigrationsCommitError(t *testing.T) {
 	mock.ExpectCommit().WillReturnError(errors.New("tx trouble maker"))
 
 	assert.PanicsWithValue(t, "Could not commit transaction: tx trouble maker", func() {
-		connector.CreateVersion("commit-sha", types.ActionApply, false, migrationsToApply)
+		connector.CreateVersion("commit-sha", types.ActionApply, migrationsToApply, false)
 	})
 
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -476,7 +476,7 @@ func TestCreateTenantTransactionBeginError(t *testing.T) {
 	migrationsToApply := []types.Migration{tenant1}
 
 	assert.PanicsWithValue(t, "Could not start transaction: trouble maker tx.Begin()", func() {
-		connector.CreateTenant("commit-sha", types.ActionApply, false, "newtenant", migrationsToApply)
+		connector.CreateTenant("newtenant", "commit-sha", types.ActionApply, migrationsToApply, false)
 	})
 
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -502,7 +502,7 @@ func TestCreateTenantCreateSchemaError(t *testing.T) {
 	migrationsToApply := []types.Migration{tenant1}
 
 	assert.PanicsWithValue(t, "Create schema failed: trouble maker", func() {
-		connector.CreateTenant("commit-sha", types.ActionApply, false, "newtenant", migrationsToApply)
+		connector.CreateTenant("newtenant", "commit-sha", types.ActionApply, migrationsToApply, false)
 	})
 
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -529,7 +529,7 @@ func TestCreateTenantInsertTenantPreparedStatementError(t *testing.T) {
 	migrationsToApply := []types.Migration{tenant1}
 
 	assert.PanicsWithValue(t, "Could not create prepared statement: trouble maker", func() {
-		connector.CreateTenant("commit-sha", types.ActionApply, false, "newtenant", migrationsToApply)
+		connector.CreateTenant("newtenant", "commit-sha", types.ActionApply, migrationsToApply, false)
 	})
 
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -559,7 +559,7 @@ func TestCreateTenantInsertTenantError(t *testing.T) {
 	migrationsToApply := []types.Migration{m1}
 
 	assert.PanicsWithValue(t, "Failed to add tenant entry: trouble maker", func() {
-		connector.CreateTenant("commit-sha", types.ActionApply, false, tenant, migrationsToApply)
+		connector.CreateTenant(tenant, "commit-sha", types.ActionApply, migrationsToApply, false)
 	})
 
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -599,7 +599,7 @@ func TestCreateTenantCommitError(t *testing.T) {
 	mock.ExpectCommit().WillReturnError(errors.New("tx trouble maker"))
 
 	assert.PanicsWithValue(t, "Could not commit transaction: tx trouble maker", func() {
-		connector.CreateTenant("commit-sha", types.ActionApply, false, tenant, migrationsToApply)
+		connector.CreateTenant(tenant, "commit-sha", types.ActionApply, migrationsToApply, false)
 	})
 
 	if err := mock.ExpectationsWereMet(); err != nil {

--- a/db/db_integration_test.go
+++ b/db/db_integration_test.go
@@ -83,7 +83,7 @@ func TestCreateVersion(t *testing.T) {
 
 			migrationsToApply := []types.Migration{public1, public2, public3, tenant1, tenant2, tenant3, public4, public5, tenant4}
 
-			results, version := connector.CreateVersion("commit-sha", types.ActionApply, false, migrationsToApply)
+			results, version := connector.CreateVersion("commit-sha", types.ActionApply, migrationsToApply, false)
 
 			assert.NotNil(t, version)
 			assert.True(t, version.ID > 0)
@@ -124,7 +124,7 @@ func TestCreateVersionEmptyMigrationArray(t *testing.T) {
 
 			migrationsToApply := []types.Migration{}
 
-			results, version := connector.CreateVersion("commit-sha", types.ActionApply, false, migrationsToApply)
+			results, version := connector.CreateVersion("commit-sha", types.ActionApply, migrationsToApply, false)
 			// empty migrations slice - no version created
 			assert.Nil(t, version)
 			assert.Equal(t, int32(0), results.MigrationsGrandTotal)
@@ -177,7 +177,7 @@ func TestCreateTenant(t *testing.T) {
 
 			uniqueTenant := fmt.Sprintf("new_test_tenant_%v", time.Now().UnixNano())
 
-			results, version := connector.CreateTenant("commit-sha", types.ActionApply, false, uniqueTenant, migrationsToApply)
+			results, version := connector.CreateTenant(uniqueTenant, "commit-sha", types.ActionApply, migrationsToApply, false)
 
 			assert.NotNil(t, version)
 			assert.True(t, version.ID > 0)

--- a/db/db_mssql.go
+++ b/db/db_mssql.go
@@ -100,14 +100,17 @@ func (md *msSQLDialect) GetCreateTenantsTableSQL() string {
 }
 
 // GetCreateMigrationsTableSQL returns migrator's create migrations table SQL statement.
-// This SQL is used by both MS SQL.
+// This SQL is used by MS SQL.
 func (md *msSQLDialect) GetCreateMigrationsTableSQL() string {
 	return fmt.Sprintf(createMigrationsTableMSSQLDialectSQL, migratorSchema, migratorMigrationsTable, migratorSchema, migratorMigrationsTable)
 }
 
 // GetCreateSchemaSQL returns create schema SQL statement.
-// This SQL is used by both MySQL and PostgreSQL.
+// This SQL is used by MS SQL.
 func (md *msSQLDialect) GetCreateSchemaSQL(schema string) string {
+	if !isValidIdentifier(schema) {
+		panic(fmt.Sprintf("Schema name contains invalid characters: %v", schema))
+	}
 	return fmt.Sprintf(createSchemaMSSQLDialectSQL, schema, schema)
 }
 

--- a/db/db_mssql_test.go
+++ b/db/db_mssql_test.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/lukaszbudnik/migrator/config"
@@ -125,6 +126,17 @@ END
 `
 
 	assert.Equal(t, expected, createSchemaSQL)
+}
+
+func TestMSSQLDialectGetCreateSchemaSQLError(t *testing.T) {
+	config, err := config.FromFile("../test/migrator-mssql.yaml")
+	assert.Nil(t, err)
+
+	dialect := newDialect(config)
+
+	sqlInjection := "abc; drop schema [migrator];"
+	expectedValue := fmt.Sprintf("Schema name contains invalid characters: %v", sqlInjection)
+	assert.PanicsWithValue(t, expectedValue, func() { dialect.GetCreateSchemaSQL(sqlInjection) })
 }
 
 func TestMSSQLGetVersionInsertSQL(t *testing.T) {

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -83,7 +83,7 @@ func TestCreateVersionDryRunMode(t *testing.T) {
 	mock.ExpectRollback()
 
 	// however the results contain correct dry-run data like number of applied migrations/scripts
-	results, version := connector.CreateVersion("commit-sha", types.ActionApply, true, migrationsToApply)
+	results, version := connector.CreateVersion("commit-sha", types.ActionApply, migrationsToApply, true)
 	assert.NotNil(t, version)
 	assert.True(t, version.ID > 0)
 	assert.Equal(t, results.MigrationsGrandTotal+results.ScriptsGrandTotal, int32(len(version.DBMigrations)))
@@ -123,7 +123,7 @@ func TestCreateVersionSyncMode(t *testing.T) {
 	mock.ExpectCommit()
 
 	// sync the results contain correct data like number of applied migrations/scripts
-	results, version := connector.CreateVersion("commit-sha", types.ActionSync, false, migrationsToApply)
+	results, version := connector.CreateVersion("commit-sha", types.ActionSync, migrationsToApply, false)
 	assert.NotNil(t, version)
 	assert.True(t, version.ID > 0)
 	assert.Equal(t, results.MigrationsGrandTotal+results.ScriptsGrandTotal, int32(len(version.DBMigrations)))
@@ -207,7 +207,7 @@ func TestCreateTenantDryRunMode(t *testing.T) {
 	mock.ExpectRollback()
 
 	// however the results contain correct dry-run data like number of applied migrations/scripts
-	results, version := connector.CreateTenant("commit-sha", types.ActionApply, true, tenant, migrationsToApply)
+	results, version := connector.CreateTenant(tenant, "commit-sha", types.ActionApply, migrationsToApply, true)
 	assert.NotNil(t, version)
 	assert.True(t, version.ID > 0)
 	assert.Equal(t, results.MigrationsGrandTotal+results.ScriptsGrandTotal, int32(len(version.DBMigrations)))
@@ -249,7 +249,7 @@ func TestCreateTenantSyncMode(t *testing.T) {
 	mock.ExpectCommit()
 
 	// sync results contain correct data like number of applied migrations/scripts
-	results, version := connector.CreateTenant("commit-sha", types.ActionSync, false, tenant, migrationsToApply)
+	results, version := connector.CreateTenant(tenant, "commit-sha", types.ActionSync, migrationsToApply, false)
 	assert.NotNil(t, version)
 	assert.True(t, version.ID > 0)
 	assert.Equal(t, results.MigrationsGrandTotal+results.ScriptsGrandTotal, int32(len(version.DBMigrations)))


### PR DESCRIPTION
Added validation function which rejects schema names which don't match [A-Za-z0-9_-]+ pattern. The validation takes place inside `GetCreateSchemaSQL` before returning the create schema SQL statements.