### PR TITLE
automerge failing on the missing [bot] suffix next to dependabot name

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -26,5 +26,5 @@ jobs:
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           MERGE_LABELS: "dependencies"
-          MERGE_FILTER_AUTHOR: "dependabot"
+          MERGE_FILTER_AUTHOR: "dependabot[bot]"
           MERGE_FORKS: "false"


### PR DESCRIPTION
automerge failing on the missing [bot] suffix next to dependabot name