### PR TITLE
publish main as edge (more popular among docker community)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -39,8 +39,6 @@ jobs:
             ghcr.io/${{ github.repository }}
           tags: |
             type=edge
-            type=ref,event=branch
-            type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}


### PR DESCRIPTION
publish main as edge (more popular among docker community)