### PR TITLE
fix for injecting build args from docker to go build

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -38,7 +38,7 @@ jobs:
             lukasz/migrator
             ghcr.io/${{ github.repository }}
           tags: |
-            type=branch
+            type=ref,event=branch
             type=edge
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,7 +2,7 @@ name: Publish Docker image
 
 on:
   push:
-    branches: [main,inject-build-envs]
+    branches: [main]
   release:
     types: [published]
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,7 +2,7 @@ name: Publish Docker image
 
 on:
   push:
-    branches: [main]
+    branches: [main,inject-build-envs]
   release:
     types: [published]
 
@@ -28,7 +28,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ github.token }}
       
       - name: Extract metadata (tags, labels) for Docker
         id: meta
@@ -38,6 +38,7 @@ jobs:
             lukasz/migrator
             ghcr.io/${{ github.repository }}
           tags: |
+            type=branch
             type=edge
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
@@ -50,3 +51,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            GIT_REF=${{ github.ref }}
+            GIT_SHA=${{ github.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,16 +2,15 @@ FROM golang:1.17.0-alpine3.13 as builder
 
 LABEL maintainer="Łukasz Budnik lukasz.budnik@gmail.com"
 
-ARG SOURCE_BRANCH
-ARG SOURCE_COMMIT
-ARG SOURCE_DATE
+ARG GIT_REF
+ARG GIT_SHA
 
 # build migrator
 RUN mkdir -p /go/migrator
 COPY . /go/migrator
 
 RUN cd /go/migrator && \
-  go build -ldflags "-X main.GitCommitDate=$SOURCE_DATE -X main.GitCommitSha=$SOURCE_COMMIT -X main.GitBranch=$SOURCE_BRANCH"
+  go build -ldflags "-X main.GitSha=$GIT_SHA -X main.GitRef=$GIT_REF"
 
 FROM alpine:3.14.1
 COPY --from=builder /go/migrator/migrator /bin

--- a/migrator.go
+++ b/migrator.go
@@ -22,18 +22,15 @@ const (
 	DefaultConfigFile = "migrator.yaml"
 )
 
-// GitBranch stores git branch/tag, value injected during production build
-var GitBranch string
+// GitRef stores git branch/tag, value injected during production build
+var GitRef string
 
-// GitCommitSha stores git commit sha, value injected during production build
-var GitCommitSha string
-
-// GitCommitDate stores git commit date time, value injected during production build
-var GitCommitDate string
+// GitSha stores git commit sha, value injected during production build
+var GitSha string
 
 func main() {
 
-	common.Log("INFO", "migrator version %v, build %v, date %v", GitBranch, GitCommitSha, GitCommitDate)
+	common.Log("INFO", "migrator version: %v (%v)", GitRef, GitSha)
 
 	flag := flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
 	buf := new(bytes.Buffer)
@@ -59,7 +56,7 @@ func main() {
 	}
 
 	gin.SetMode(gin.ReleaseMode)
-	versionInfo := &types.VersionInfo{Release: GitBranch, CommitSha: GitCommitSha, CommitDate: GitCommitDate, APIVersions: []types.APIVersion{types.APIV2}}
+	versionInfo := &types.VersionInfo{Release: GitRef, Sha: GitSha, APIVersions: []types.APIVersion{types.APIV2}}
 	g := server.SetupRouter(versionInfo, cfg, createCoordinator)
 	if err := g.Run(":" + server.GetPort(cfg)); err != nil {
 		common.Log("ERROR", "Error starting migrator: %v", err)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -32,7 +32,7 @@ func newTestRequestV2(method, url string, body io.Reader) (*http.Request, error)
 }
 
 func testSetupRouter(config *config.Config, newCoordinator func(ctx context.Context, config *config.Config) coordinator.Coordinator) *gin.Engine {
-	versionInfo := &types.VersionInfo{Release: "GitBranch", CommitSha: "GitCommitSha", CommitDate: "2020-01-08T09:56:41+01:00", APIVersions: []types.APIVersion{types.APIV2}}
+	versionInfo := &types.VersionInfo{Release: "GitRef", Sha: "GitSha", APIVersions: []types.APIVersion{types.APIV2}}
 	gin.SetMode(gin.ReleaseMode)
 	return SetupRouter(versionInfo, config, newCoordinator)
 }
@@ -63,7 +63,7 @@ func TestRoot(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, "application/json; charset=utf-8", w.HeaderMap["Content-Type"][0])
-	assert.Equal(t, `{"release":"GitBranch","commitSha":"GitCommitSha","commitDate":"2020-01-08T09:56:41+01:00","apiVersions":["v2"]}`, strings.TrimSpace(w.Body.String()))
+	assert.Equal(t, `{"release":"GitRef","sha":"GitSha","apiVersions":["v2"]}`, strings.TrimSpace(w.Body.String()))
 }
 
 func TestRootWithPathPrefix(t *testing.T) {
@@ -80,7 +80,7 @@ func TestRootWithPathPrefix(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, "application/json; charset=utf-8", w.HeaderMap["Content-Type"][0])
-	assert.Equal(t, `{"release":"GitBranch","commitSha":"GitCommitSha","commitDate":"2020-01-08T09:56:41+01:00","apiVersions":["v2"]}`, strings.TrimSpace(w.Body.String()))
+	assert.Equal(t, `{"release":"GitRef","sha":"GitSha","apiVersions":["v2"]}`, strings.TrimSpace(w.Body.String()))
 }
 
 // /v1 API

--- a/test/docker-compose.yaml
+++ b/test/docker-compose.yaml
@@ -85,7 +85,7 @@ services:
         fi
         wait $$PID
   migrator:
-    image: lukasz/migrator
+    image: lukasz/migrator:latest
     depends_on:
       - mysql
       - mariadb
@@ -106,7 +106,7 @@ services:
       - mssql
   migrator-dev:
     image: migrator-dev
-    build: 
+    build:
       context: ..
       dockerfile: test/migrator-dev/Dockerfile
     depends_on:

--- a/test/migrator-dev/Dockerfile
+++ b/test/migrator-dev/Dockerfile
@@ -1,9 +1,8 @@
-FROM golang:1.16.2-alpine3.13 as builder
+FROM golang:1.17.0-alpine3.13 as builder
 
 LABEL maintainer="Łukasz Budnik lukasz.budnik@gmail.com"
 
-# use "--build-arg SOURCE_BRANCH=dev" to override at build time
-# docker build -f TestDockerfile --build-arg SOURCE_BRANCH=dev -t migrator-local:dev .
+# use SOURCE_BRANCH to override at build time
 ARG SOURCE_BRANCH=main
 
 # git is required
@@ -18,12 +17,11 @@ COPY . /go/migrator
 # RUN cd /go/migrator && git checkout $SOURCE_BRANCH
 
 RUN cd /go/migrator && \
-  GIT_BRANCH=$(git branch | awk -v FS=' ' '/\*/{print $NF}' | sed 's|[()]||g') && \
-  GIT_COMMIT_DATE=$(git log -n1 --date=iso-strict | grep 'Date:' | sed 's|Date:\s*||g') && \
-  GIT_COMMIT_SHA=$(git rev-list -1 HEAD) && \
-  go build -ldflags "-X main.GitCommitDate=$GIT_COMMIT_DATE -X main.GitCommitSha=$GIT_COMMIT_SHA -X main.GitBranch=$GIT_BRANCH"
+  GIT_REF=$(git branch | awk -v FS=' ' '/\*/{print $NF}' | sed 's|[()]||g') && \
+  GIT_SHA=$(git rev-list -1 HEAD) && \
+  go build -ldflags "-X main.GitSha=$GIT_SHA -X main.GitRef=$GIT_REF"
 
-FROM alpine:3.13.2
+FROM alpine:3.14.1
 COPY --from=builder /go/migrator/migrator /bin
 
 VOLUME ["/data"]

--- a/types/types.go
+++ b/types/types.go
@@ -194,7 +194,6 @@ const (
 // VersionInfo contains build information and supported API versions
 type VersionInfo struct {
 	Release     string       `json:"release"`
-	CommitSha   string       `json:"commitSha"`
-	CommitDate  string       `json:"commitDate"`
+	Sha         string       `json:"sha"`
 	APIVersions []APIVersion `json:"apiVersions"`
 }


### PR DESCRIPTION
Fix for injecting build args from docker to go build.

The build args were empty after the migration from Docker Hub autobuild to GitHub actions.