### PR TITLE
update alpine builder image in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17.5-alpine3.14 as builder
+FROM golang:1.17.5-alpine3.15 as builder
 
 LABEL org.opencontainers.image.authors="Łukasz Budnik <lukasz.budnik@gmail.com>"
 

--- a/test/migrator-dev/Dockerfile
+++ b/test/migrator-dev/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17.5-alpine3.14 as builder
+FROM golang:1.17.5-alpine3.15 as builder
 
 LABEL org.opencontainers.image.authors="Łukasz Budnik <lukasz.budnik@gmail.com>"
 


### PR DESCRIPTION
Maintenance pull: contains update of go alpine from `golang:1.17.5-alpine3.14` to ` golang:1.17.5-alpine3.15`